### PR TITLE
chore(deps): repoint revm patch to public mantle-xyz/revm @ v107-mant…

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6544,7 +6544,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "19.0.0"
-source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
+source = "git+https://github.com/mantle-xyz/revm?tag=v107-mantle-arsia.1#1ed03aace7313c8f52a7282983a0c46cc8691d0e"
 dependencies = [
  "alloy-sol-types",
  "auto_impl",
@@ -7610,7 +7610,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "38.0.0"
-source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
+source = "git+https://github.com/mantle-xyz/revm?tag=v107-mantle-arsia.1#1ed03aace7313c8f52a7282983a0c46cc8691d0e"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -7628,7 +7628,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "10.0.0"
-source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
+source = "git+https://github.com/mantle-xyz/revm?tag=v107-mantle-arsia.1#1ed03aace7313c8f52a7282983a0c46cc8691d0e"
 dependencies = [
  "bitvec",
  "phf",
@@ -7639,7 +7639,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "16.0.1"
-source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
+source = "git+https://github.com/mantle-xyz/revm?tag=v107-mantle-arsia.1#1ed03aace7313c8f52a7282983a0c46cc8691d0e"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -7655,7 +7655,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "17.0.1"
-source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
+source = "git+https://github.com/mantle-xyz/revm?tag=v107-mantle-arsia.1#1ed03aace7313c8f52a7282983a0c46cc8691d0e"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -7670,7 +7670,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "13.0.1"
-source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
+source = "git+https://github.com/mantle-xyz/revm?tag=v107-mantle-arsia.1#1ed03aace7313c8f52a7282983a0c46cc8691d0e"
 dependencies = [
  "alloy-eips 1.8.3",
  "revm-bytecode",
@@ -7683,7 +7683,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "11.0.1"
-source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
+source = "git+https://github.com/mantle-xyz/revm?tag=v107-mantle-arsia.1#1ed03aace7313c8f52a7282983a0c46cc8691d0e"
 dependencies = [
  "auto_impl",
  "either",
@@ -7696,7 +7696,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "18.1.0"
-source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
+source = "git+https://github.com/mantle-xyz/revm?tag=v107-mantle-arsia.1#1ed03aace7313c8f52a7282983a0c46cc8691d0e"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -7714,7 +7714,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "19.0.0"
-source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
+source = "git+https://github.com/mantle-xyz/revm?tag=v107-mantle-arsia.1#1ed03aace7313c8f52a7282983a0c46cc8691d0e"
 dependencies = [
  "auto_impl",
  "either",
@@ -7731,7 +7731,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "35.0.1"
-source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
+source = "git+https://github.com/mantle-xyz/revm?tag=v107-mantle-arsia.1#1ed03aace7313c8f52a7282983a0c46cc8691d0e"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -7743,7 +7743,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "34.0.0"
-source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
+source = "git+https://github.com/mantle-xyz/revm?tag=v107-mantle-arsia.1#1ed03aace7313c8f52a7282983a0c46cc8691d0e"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -7768,7 +7768,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "23.0.0"
-source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
+source = "git+https://github.com/mantle-xyz/revm?tag=v107-mantle-arsia.1#1ed03aace7313c8f52a7282983a0c46cc8691d0e"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -7779,7 +7779,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "11.0.1"
-source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
+source = "git+https://github.com/mantle-xyz/revm?tag=v107-mantle-arsia.1#1ed03aace7313c8f52a7282983a0c46cc8691d0e"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.11.1",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -30,7 +30,7 @@ members = [
   # Alloy OP Hardforks
   "alloy-op-hardforks/",
 
-  # Op-Revm: sourced from mantle-xyz/revm-ghsa-5vfr-x84h-hmvf @ 99707e9f via [patch.crates-io]
+  # Op-Revm: sourced from mantle-xyz/revm @ tag v107-mantle-arsia.1 via [patch.crates-io]
   # below; the local op-revm/ subtree is intentionally excluded from the workspace.
   # "op-revm/",
 ]
@@ -353,7 +353,7 @@ reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7fcbfdeb
 reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7fcbfdebfd3b56d88c86b62e950043c6c4", default-features = false }
 reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7fcbfdebfd3b56d88c86b62e950043c6c4" }
 
-# ==================== REVM (redirected to mantle-xyz/revm-ghsa-5vfr-x84h-hmvf @ 99707e9f via [patch.crates-io]; declared versions track upstream to satisfy transitive constraints) ====================
+# ==================== REVM (redirected to mantle-xyz/revm @ tag v107-mantle-arsia.1 via [patch.crates-io]; declared versions track upstream to satisfy transitive constraints) ====================
 revm = { version = "38.0.0", default-features = false }
 revm-bytecode = { version = "10.0.0", default-features = false }
 revm-database = { version = "13.0.0", default-features = false }
@@ -629,21 +629,21 @@ snmalloc-rs = { version = "0.3.8", features = ["build_cc"] }
 # K/V database
 rocksdb = { version = "0.24.0", default-features = false }
 
-# ==================== PATCH: redirect every revm-* crate (including those pulled transitively) to mantle-xyz/revm-ghsa-5vfr-x84h-hmvf @ 99707e9f ====================
+# ==================== PATCH: redirect every revm-* crate (including those pulled transitively) to mantle-xyz/revm @ tag v107-mantle-arsia.1 ====================
 [patch.crates-io]
-revm = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-bytecode = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-context = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-context-interface = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-database = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-database-interface = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-handler = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-inspector = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-interpreter = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-precompile = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-primitives = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-state = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-op-revm = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
+revm = { git = "https://github.com/mantle-xyz/revm", tag = "v107-mantle-arsia.1" }
+revm-bytecode = { git = "https://github.com/mantle-xyz/revm", tag = "v107-mantle-arsia.1" }
+revm-context = { git = "https://github.com/mantle-xyz/revm", tag = "v107-mantle-arsia.1" }
+revm-context-interface = { git = "https://github.com/mantle-xyz/revm", tag = "v107-mantle-arsia.1" }
+revm-database = { git = "https://github.com/mantle-xyz/revm", tag = "v107-mantle-arsia.1" }
+revm-database-interface = { git = "https://github.com/mantle-xyz/revm", tag = "v107-mantle-arsia.1" }
+revm-handler = { git = "https://github.com/mantle-xyz/revm", tag = "v107-mantle-arsia.1" }
+revm-inspector = { git = "https://github.com/mantle-xyz/revm", tag = "v107-mantle-arsia.1" }
+revm-interpreter = { git = "https://github.com/mantle-xyz/revm", tag = "v107-mantle-arsia.1" }
+revm-precompile = { git = "https://github.com/mantle-xyz/revm", tag = "v107-mantle-arsia.1" }
+revm-primitives = { git = "https://github.com/mantle-xyz/revm", tag = "v107-mantle-arsia.1" }
+revm-state = { git = "https://github.com/mantle-xyz/revm", tag = "v107-mantle-arsia.1" }
+op-revm = { git = "https://github.com/mantle-xyz/revm", tag = "v107-mantle-arsia.1" }
 
 # [MANTLE] alloy-evm is intentionally NOT patched: it resolves from crates.io, which is
 # upstream alloy-rs/evm v0.34.0. The previous mantle-xyz/evm@mantle-v0.34.0 fork existed


### PR DESCRIPTION
…le-arsia.1

Replace the private mantle-xyz/revm-ghsa-5vfr-x84h-hmvf @ 99707e9f pin with the public mantle-xyz/revm repository at tag v107-mantle-arsia.1 (1ed03aace7313c8f52a7282983a0c46cc8691d0e), so the workspace no longer requires credentials for a private repo to build.

The tag's history contains the previously pinned fix (1ac02c340 "treat zero BVM_ETH eth_value/eth_tx_value as None in deposit") plus follow-ups: op-geth parity for deposit pre-call gates and the Isthmus precompile set, ARSIA spec restore on the block-59294 deposit replay test, and CI/docs fixes.

Cargo.lock: only the 13 `source =` lines change; crate versions and the dependency graph are untouched.