### PR TITLE
Add PreconfWhitelist contract

### DIFF
--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -438,6 +438,9 @@ contract L2Genesis is Script {
         // BVM_ETH has immutables. Deploy a real instance so the constructor patches
         // them into the runtime code, then etch that code at the predeploy address.
         // name()/symbol() are constant overrides and do not require storage copying.
+        // BVM_ETH's constructor takes no arguments, so there is nothing for
+        // DeployUtils.encodeConstructor to wrap — it rejects payloads shorter than 4 bytes.
+        // nosemgrep: sol-safety-deployutils-args
         address bvmEth = DeployUtils.create1({ _name: "BVM_ETH.sol:BVM_ETH", _args: "" });
         vm.etch(Predeploys.BVM_ETH, address(bvmEth).code);
         vm.etch(bvmEth, "");
@@ -448,7 +451,9 @@ contract L2Genesis is Script {
     function setBaseFeeVault(Input memory _input) internal {
         address vault = DeployUtils.create1({
             _name: "BaseFeeVault",
-            _args: DeployUtils.encodeConstructor(abi.encodeCall(IFeeVault.__constructor__, (_input.baseFeeVaultRecipient)))
+            _args: DeployUtils.encodeConstructor(
+                abi.encodeCall(IFeeVault.__constructor__, (_input.baseFeeVaultRecipient))
+            )
         });
 
         address impl = Predeploys.predeployToCodeNamespace(Predeploys.BASE_FEE_VAULT);
@@ -463,7 +468,9 @@ contract L2Genesis is Script {
     function setL1FeeVault(Input memory _input) internal {
         address vault = DeployUtils.create1({
             _name: "L1FeeVault",
-            _args: DeployUtils.encodeConstructor(abi.encodeCall(IFeeVault.__constructor__, (_input.l1FeeVaultRecipient)))
+            _args: DeployUtils.encodeConstructor(
+                abi.encodeCall(IFeeVault.__constructor__, (_input.l1FeeVaultRecipient))
+            )
         });
 
         address impl = Predeploys.predeployToCodeNamespace(Predeploys.L1_FEE_VAULT);

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -451,9 +451,7 @@ contract L2Genesis is Script {
     function setBaseFeeVault(Input memory _input) internal {
         address vault = DeployUtils.create1({
             _name: "BaseFeeVault",
-            _args: DeployUtils.encodeConstructor(
-                abi.encodeCall(IFeeVault.__constructor__, (_input.baseFeeVaultRecipient))
-            )
+            _args: DeployUtils.encodeConstructor(abi.encodeCall(IFeeVault.__constructor__, (_input.baseFeeVaultRecipient)))
         });
 
         address impl = Predeploys.predeployToCodeNamespace(Predeploys.BASE_FEE_VAULT);
@@ -468,9 +466,7 @@ contract L2Genesis is Script {
     function setL1FeeVault(Input memory _input) internal {
         address vault = DeployUtils.create1({
             _name: "L1FeeVault",
-            _args: DeployUtils.encodeConstructor(
-                abi.encodeCall(IFeeVault.__constructor__, (_input.l1FeeVaultRecipient))
-            )
+            _args: DeployUtils.encodeConstructor(abi.encodeCall(IFeeVault.__constructor__, (_input.l1FeeVaultRecipient)))
         });
 
         address impl = Predeploys.predeployToCodeNamespace(Predeploys.L1_FEE_VAULT);

--- a/packages/contracts-bedrock/src/L1/PreconfWhitelistGov.sol
+++ b/packages/contracts-bedrock/src/L1/PreconfWhitelistGov.sol
@@ -14,6 +14,16 @@ contract PreconfWhitelistGov is Ownable {
     ///         bought, so rejecting it here — where the length is plain calldata — is free.
     uint256 public constant MAX_BATCH = PRECONF_MAX_BATCH;
 
+    /// @notice Gas the computed limit buys per rule. A pair add measures 68,044 on L2 — the worst
+    ///         per-rule cost — so this carries a 2.9% margin, and a full batch buys 18.2M of the 20M
+    ///         a deposit can. Raising `MAX_BATCH` past 281 breaks that; see the test.
+    uint64 public constant GAS_PER_RULE = 70_000;
+
+    /// @notice Gas a rotation buys on L2 above the portal's calldata floor. `setAuthorizedL1` is one
+    ///         SSTORE plus an event — 2,769 measured warm, so this is an order of magnitude of
+    ///         margin. It takes no array, so there is nothing for a caller to size.
+    uint64 public constant ROTATE_GAS = 60_000;
+
     /// @notice The OptimismPortal this contract deposits through. Immutable — it does not move.
     // nosemgrep: sol-safety-no-immutable-variables -- this contract is not proxied
     OptimismPortal public immutable PORTAL;
@@ -50,15 +60,28 @@ contract PreconfWhitelistGov is Ownable {
         emit WhitelistSet(_whitelist);
     }
 
-    /// @notice Relays a rule delta to L2. A starved `_gasLimit` fails on L2 while this L1 call still
-    ///         succeeds, and there is no permissionless replay to recover through — so verify on L2,
-    ///         and re-send larger if it did not land.
+    /// @notice Relays a rule delta to L2, sizing the gas from the batch so that nothing about gas is
+    ///         left to the caller. Verify on L2 all the same: a starved deposit fails there while
+    ///         this L1 call still succeeds, and no permissionless replay exists to recover through.
+    /// @param _add    Rules to authorize.
+    /// @param _remove Rules to revoke.
+    function updatePreconfs(
+        PreconfWhitelist.Rule[] calldata _add,
+        PreconfWhitelist.Rule[] calldata _remove
+    )
+        external
+        onlyOwner
+    {
+        _update(_add, _remove, 0);
+    }
+
+    /// @notice The same, with the L2 gas limit named explicitly. For when the L2 side has been
+    ///         redeployed with costs [`GAS_PER_RULE`] no longer describes — a separate function
+    ///         rather than a sentinel so that the multisig queue shows which path was taken.
     /// @param _add      Rules to authorize.
     /// @param _remove   Rules to revoke.
-    /// @param _gasLimit L2 gas to buy. Not checked here beyond the portal's own `minimumGasLimit`:
-    ///                  what a batch costs is a property of the L2 bytecode, which this side cannot
-    ///                  measure. Size it from the `MAX_BATCH` table in `PreconfWhitelist`.
-    function updatePreconfs(
+    /// @param _gasLimit L2 gas to buy. Zero is rejected: that is [`updatePreconfs`]'s job.
+    function updatePreconfsWithGasLimit(
         PreconfWhitelist.Rule[] calldata _add,
         PreconfWhitelist.Rule[] calldata _remove,
         uint64 _gasLimit
@@ -66,22 +89,46 @@ contract PreconfWhitelistGov is Ownable {
         external
         onlyOwner
     {
-        require(_add.length + _remove.length <= MAX_BATCH, "PreconfWhitelistGov: batch too large");
+        require(_gasLimit != 0, "PreconfWhitelistGov: gas limit is zero");
 
-        _deposit(abi.encodeCall(PreconfWhitelist.updatePreconfs, (_add, _remove)), _gasLimit);
+        _update(_add, _remove, _gasLimit);
+    }
+
+    /// @notice Bounds the batch, encodes it, and buys the deposit.
+    /// @param _add      Rules to authorize.
+    /// @param _remove   Rules to revoke.
+    /// @param _gasLimit L2 gas to buy, or zero to size it at [`GAS_PER_RULE`] per rule on top of the
+    ///                  portal's own calldata floor.
+    function _update(
+        PreconfWhitelist.Rule[] calldata _add,
+        PreconfWhitelist.Rule[] calldata _remove,
+        uint64 _gasLimit
+    )
+        internal
+    {
+        uint256 count = _add.length + _remove.length;
+        require(count <= MAX_BATCH, "PreconfWhitelistGov: batch too large");
+
+        bytes memory data = abi.encodeCall(PreconfWhitelist.updatePreconfs, (_add, _remove));
+        if (_gasLimit == 0) {
+            _gasLimit = PORTAL.minimumGasLimit(uint64(data.length)) + GAS_PER_RULE * uint64(count);
+        }
+        _deposit(data, _gasLimit);
     }
 
     /// @notice Hands governance of the L2 allowlist to another L1 address. One-way and unconfirmed.
     ///         The has-code check is the one guard only L1 can run — L2 cannot inspect an L1
     ///         address, and its gate admits only aliased (i.e. contract) senders.
-    /// @param _authorizedL1 New L1 governance address, unaliased. Must already hold code; the check
-    ///                      filters EOAs and typos, not every wrong contract.
-    /// @param _gasLimit     L2 gas to buy; `setAuthorizedL1` is one packed SSTORE plus an event.
-    function rotateAuthorizedL1(address _authorizedL1, uint64 _gasLimit) external onlyOwner {
+    /// @param _authorizedL1 New L1 governance address, unaliased. Must already hold code and differ
+    ///                      from this contract; the checks filter EOAs, typos and the no-op rotation
+    ///                      that would still emit `AuthorizedL1Updated` on L2, not every wrong one.
+    function rotateAuthorizedL1(address _authorizedL1) external onlyOwner {
         require(_authorizedL1 != address(0), "PreconfWhitelistGov: authorized L1 sender is the zero address");
+        require(_authorizedL1 != address(this), "PreconfWhitelistGov: authorized L1 sender is this contract");
         require(_authorizedL1.code.length > 0, "PreconfWhitelistGov: authorized L1 sender is not a contract");
 
-        _deposit(abi.encodeCall(PreconfWhitelist.setAuthorizedL1, (_authorizedL1)), _gasLimit);
+        bytes memory data = abi.encodeCall(PreconfWhitelist.setAuthorizedL1, (_authorizedL1));
+        _deposit(data, PORTAL.minimumGasLimit(uint64(data.length)) + ROTATE_GAS);
     }
 
     /// @notice Buys one L2 deposit addressed at [`whitelist`]. All four value arguments are zero: a

--- a/packages/contracts-bedrock/src/L1/PreconfWhitelistGov.sol
+++ b/packages/contracts-bedrock/src/L1/PreconfWhitelistGov.sol
@@ -14,14 +14,19 @@ contract PreconfWhitelistGov is Ownable {
     ///         bought, so rejecting it here — where the length is plain calldata — is free.
     uint256 public constant MAX_BATCH = PRECONF_MAX_BATCH;
 
+    /// @notice Fixed part of the computed limit: dispatch, decode, the event's cold SLOADs and the
+    ///         cold length SSTORE are paid once per call, not per rule, so [`GAS_PER_RULE`]'s
+    ///         full-batch average under-buys small ones. One rule measures 91,597: 21,597 needed.
+    uint64 public constant BASE_GAS = 30_000;
+
     /// @notice Gas the computed limit buys per rule. A pair add measures 68,044 on L2 — the worst
     ///         per-rule cost — so this carries a 2.9% margin, and a full batch buys 18.2M of the 20M
     ///         a deposit can. Raising `MAX_BATCH` past 281 breaks that; see the test.
     uint64 public constant GAS_PER_RULE = 70_000;
 
-    /// @notice Gas a rotation buys on L2 above the portal's calldata floor. `setAuthorizedL1` is one
-    ///         SSTORE plus an event — 2,769 measured warm, so this is an order of magnitude of
-    ///         margin. It takes no array, so there is nothing for a caller to size.
+    /// @notice Gas a rotation buys above the portal's calldata floor. `setAuthorizedL1` is one SSTORE
+    ///         plus an event — 2,769 warm, so roughly 7,000 cold and about 28,400 for the whole L2
+    ///         transaction, against the 81,576 this buys. No array, so nothing for a caller to size.
     uint64 public constant ROTATE_GAS = 60_000;
 
     /// @notice The OptimismPortal this contract deposits through. Immutable — it does not move.
@@ -60,9 +65,9 @@ contract PreconfWhitelistGov is Ownable {
         emit WhitelistSet(_whitelist);
     }
 
-    /// @notice Relays a rule delta to L2, sizing the gas from the batch so that nothing about gas is
-    ///         left to the caller. Verify on L2 all the same: a starved deposit fails there while
-    ///         this L1 call still succeeds, and no permissionless replay exists to recover through.
+    /// @notice Relays a rule delta to L2, sizing the gas itself — a fixed term plus a per-rule one,
+    ///         since a per-rule term alone under-buys the common small batch. Verify on L2 anyway: a
+    ///         starved deposit fails there while this L1 call succeeds, with no replay to recover it.
     /// @param _add    Rules to authorize.
     /// @param _remove Rules to revoke.
     function updatePreconfs(
@@ -97,8 +102,8 @@ contract PreconfWhitelistGov is Ownable {
     /// @notice Bounds the batch, encodes it, and buys the deposit.
     /// @param _add      Rules to authorize.
     /// @param _remove   Rules to revoke.
-    /// @param _gasLimit L2 gas to buy, or zero to size it at [`GAS_PER_RULE`] per rule on top of the
-    ///                  portal's own calldata floor.
+    /// @param _gasLimit L2 gas to buy, or zero to size it as the portal's calldata floor plus
+    ///                  [`BASE_GAS`] plus [`GAS_PER_RULE`] per rule.
     function _update(
         PreconfWhitelist.Rule[] calldata _add,
         PreconfWhitelist.Rule[] calldata _remove,
@@ -111,7 +116,7 @@ contract PreconfWhitelistGov is Ownable {
 
         bytes memory data = abi.encodeCall(PreconfWhitelist.updatePreconfs, (_add, _remove));
         if (_gasLimit == 0) {
-            _gasLimit = PORTAL.minimumGasLimit(uint64(data.length)) + GAS_PER_RULE * uint64(count);
+            _gasLimit = PORTAL.minimumGasLimit(uint64(data.length)) + BASE_GAS + GAS_PER_RULE * uint64(count);
         }
         _deposit(data, _gasLimit);
     }

--- a/packages/contracts-bedrock/src/L1/PreconfWhitelistGov.sol
+++ b/packages/contracts-bedrock/src/L1/PreconfWhitelistGov.sol
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { OptimismPortal } from "./OptimismPortal.sol";
+import { PreconfWhitelist, PRECONF_MAX_BATCH } from "../L2/PreconfWhitelist.sol";
+
+/// @title PreconfWhitelistGov
+/// @notice L1 endpoint governing `PreconfWhitelist`; it is that contract's `authorizedL1`. Deposits
+///         via OptimismPortal, never the messenger: a delta needs exactly-once, in-order delivery.
+contract PreconfWhitelistGov is Ownable {
+    /// @notice The same constant `PreconfWhitelist` caps a batch with, imported rather than copied
+    ///         so the two cannot drift. An oversized batch reverts on L2 only after the deposit is
+    ///         bought, so rejecting it here — where the length is plain calldata — is free.
+    uint256 public constant MAX_BATCH = PRECONF_MAX_BATCH;
+
+    /// @notice The OptimismPortal this contract deposits through. Immutable — it does not move.
+    // nosemgrep: sol-safety-no-immutable-variables -- this contract is not proxied
+    OptimismPortal public immutable PORTAL;
+
+    /// @notice The L2 `PreconfWhitelist` under governance. Settable: it cannot exist at construction
+    ///         time, because it takes our address.
+    address public whitelist;
+
+    /// @notice Emitted when the governed L2 contract is set or repointed.
+    /// @param whitelist The L2 `PreconfWhitelist` this contract now governs.
+    event WhitelistSet(address indexed whitelist);
+
+    /// @notice The L1-side record of every deposit sent. The L2 outcome is not observable from here.
+    /// @param target   L2 contract the deposit is addressed to.
+    /// @param gasLimit L2 gas bought for it.
+    /// @param data     Calldata the L2 transaction will carry.
+    event GovernanceDeposited(address indexed target, uint64 gasLimit, bytes data);
+
+    /// @notice Wires this endpoint to its portal and owner.
+    /// @param _portal The OptimismPortal to deposit through.
+    /// @param _owner  Address permitted to govern, normally the governance Safe.
+    constructor(OptimismPortal _portal, address _owner) {
+        require(address(_portal) != address(0), "PreconfWhitelistGov: portal is the zero address");
+        require(_owner != address(0), "PreconfWhitelistGov: owner is the zero address");
+        PORTAL = _portal;
+        _transferOwnership(_owner);
+    }
+
+    /// @notice Points this contract at the L2 `PreconfWhitelist` it governs.
+    /// @param _whitelist L2 address. Not checked for code — it lives on the other chain, so nothing
+    ///                   here could check it.
+    function setWhitelist(address _whitelist) external onlyOwner {
+        whitelist = _whitelist;
+        emit WhitelistSet(_whitelist);
+    }
+
+    /// @notice Relays a rule delta to L2. A starved `_gasLimit` fails on L2 while this L1 call still
+    ///         succeeds, and there is no permissionless replay to recover through — so verify on L2,
+    ///         and re-send larger if it did not land.
+    /// @param _add      Rules to authorize.
+    /// @param _remove   Rules to revoke.
+    /// @param _gasLimit L2 gas to buy. Not checked here beyond the portal's own `minimumGasLimit`:
+    ///                  what a batch costs is a property of the L2 bytecode, which this side cannot
+    ///                  measure. Size it from the `MAX_BATCH` table in `PreconfWhitelist`.
+    function updatePreconfs(
+        PreconfWhitelist.Rule[] calldata _add,
+        PreconfWhitelist.Rule[] calldata _remove,
+        uint64 _gasLimit
+    )
+        external
+        onlyOwner
+    {
+        require(_add.length + _remove.length <= MAX_BATCH, "PreconfWhitelistGov: batch too large");
+
+        _deposit(abi.encodeCall(PreconfWhitelist.updatePreconfs, (_add, _remove)), _gasLimit);
+    }
+
+    /// @notice Hands governance of the L2 allowlist to another L1 address. One-way and unconfirmed.
+    ///         The has-code check is the one guard only L1 can run — L2 cannot inspect an L1
+    ///         address, and its gate admits only aliased (i.e. contract) senders.
+    /// @param _authorizedL1 New L1 governance address, unaliased. Must already hold code; the check
+    ///                      filters EOAs and typos, not every wrong contract.
+    /// @param _gasLimit     L2 gas to buy; `setAuthorizedL1` is one packed SSTORE plus an event.
+    function rotateAuthorizedL1(address _authorizedL1, uint64 _gasLimit) external onlyOwner {
+        require(_authorizedL1 != address(0), "PreconfWhitelistGov: authorized L1 sender is the zero address");
+        require(_authorizedL1.code.length > 0, "PreconfWhitelistGov: authorized L1 sender is not a contract");
+
+        _deposit(abi.encodeCall(PreconfWhitelist.setAuthorizedL1, (_authorizedL1)), _gasLimit);
+    }
+
+    /// @notice Buys one L2 deposit addressed at [`whitelist`]. All four value arguments are zero: a
+    ///         non-zero `_mntValue` would make the portal pull MNT from this contract.
+    /// @param _data     Calldata for the L2 transaction.
+    /// @param _gasLimit L2 gas to buy, metered directly against `maxResourceLimit` with no
+    ///                  `baseGas` conversion on this channel.
+    function _deposit(bytes memory _data, uint64 _gasLimit) internal {
+        address target = whitelist;
+        require(target != address(0), "PreconfWhitelistGov: whitelist not set");
+
+        emit GovernanceDeposited(target, _gasLimit, _data);
+        PORTAL.depositTransaction({
+            _ethTxValue: 0,
+            _mntValue: 0,
+            _to: target,
+            _mntTxValue: 0,
+            _gasLimit: _gasLimit,
+            _isCreation: false,
+            _data: _data
+        });
+    }
+
+    /// @notice Always reverts. Renouncing would strand the L2 allowlist: only this contract can
+    ///         write to it, and reaching it needs an owner. [`rotateAuthorizedL1`] is the way out.
+    function renounceOwnership() public pure override {
+        revert("PreconfWhitelistGov: ownership cannot be renounced");
+    }
+}

--- a/packages/contracts-bedrock/src/L2/PreconfWhitelist.sol
+++ b/packages/contracts-bedrock/src/L2/PreconfWhitelist.sol
@@ -1,0 +1,444 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { L2CrossDomainMessenger } from "./L2CrossDomainMessenger.sol";
+
+/// @title PreconfWhitelist
+/// @notice Authoritative on-chain storage for the sequencer's preconfirmation allowlist. The
+///         sequencer (op-reth) mirrors these three sets into memory and consults them when
+///         deciding whether a transaction is eligible for the preconf fast path.
+///
+///         Eligibility is an **explicit `(from, to)` relation**, not a cross product:
+///
+///           eligible(from, to)  <=>  isWhitelistPair(from, to)
+///                                ||  isFromWildcard(from)
+///                                ||  isToWildcard(to)
+///
+///         The predicate is a plain OR with no precedence and no deny list. In particular,
+///         removing `(A, X)` from the pair set does NOT stop `A -> X` if `A` is still a from
+///         wildcard; the wildcard has to be removed too.
+///
+///         Updates may only originate from a single authorized L1 address (the governance Safe),
+///         relayed through the standard OP-Stack L1->L2 CrossDomainMessenger channel. No L1
+///         contract is deployed for this: governance calls `L1CrossDomainMessenger.sendMessage`
+///         directly, which becomes an OptimismPortal deposit and lands here via
+///         `L2CrossDomainMessenger.relayMessage`.
+///
+///         This is a regular deployed contract, NOT a predeploy — it is deployed with a normal L2
+///         transaction and its address is passed to op-reth via `--preconf.whitelist-address`.
+///
+/// @dev    STORAGE LAYOUT IS LOAD-BEARING. op-reth reads `pairs` (slot 0), `fromWildcards`
+///         (slot 2) and `toWildcards` (slot 4) directly out of state — it never calls the view
+///         functions below, because the classifier's eligibility check is a synchronous,
+///         no-IO hot path that reads an in-memory mirror. The six state variables must therefore
+///         keep their exact order and slot assignment. Do NOT insert, reorder, or remove state
+///         variables, and do not add a base contract that declares storage. The Rust side pins the
+///         same numbers in `mantle-reth/crates/preconf/src/whitelist.rs`
+///         (`PAIRS_SLOT` / `FROM_WILDCARDS_SLOT` / `TO_WILDCARDS_SLOT`);
+///         `test/PreconfWhitelist.t.sol` asserts the layout so a drift breaks CI here first.
+///         `layoutVersion` (slot 6) is the runtime guard for the same coupling — see its docs.
+///
+///         Note especially that a `Pair` element spans **two** slots: two addresses are 40 bytes,
+///         so they cannot share one. `pairs[i].from` lives at `keccak256(0) + 2i` and
+///         `pairs[i].to` at `keccak256(0) + 2i + 1`. The Rust reader depends on that stride.
+contract PreconfWhitelist {
+    /// @notice One allowlist rule. Both halves non-zero means an exact match; exactly one zero
+    ///         half means a wildcard on the other side (see `updatePreconfs`). Stored entries in
+    ///         `pairs` always have both halves non-zero — the zero address is a calldata-only
+    ///         marker and never reaches storage.
+    struct Pair {
+        address from;
+        address to;
+    }
+
+    /// @notice The L2CrossDomainMessenger predeploy — the only permitted direct caller of
+    ///         `updatePreconfs`. Cross-domain messages are relayed to us through it.
+    /// @dev    Held as an `address` because a cast to a contract type is not a compile-time
+    ///         constant; the cast happens at the call site (same as `CrossDomainOwnable2`).
+    ///         Spelled as a literal rather than `Predeploys.L2_CROSS_DOMAIN_MESSENGER` because
+    ///         solc 0.8.15 rejects a library constant in a constant initializer; the value is
+    ///         asserted equal to that constant in `test/PreconfWhitelist.t.sol`.
+    address internal constant MESSENGER = 0x4200000000000000000000000000000000000007;
+
+    /// @notice The one L1 address permitted to govern this allowlist (the governance Safe), stored
+    ///         unaliased. This is the address that calls `L1CrossDomainMessenger.sendMessage`, as
+    ///         reported by `xDomainMessageSender()` during relay.
+    /// @dev    Immutable, so it occupies no storage slot and cannot shift the layout below.
+    ///         Rotating the governance Safe therefore requires redeploying this contract and
+    ///         repointing op-reth at the new address.
+    address public immutable AUTHORIZED_L1;
+
+    /// @notice Exact `(from, to)` rules. Slot 0 — see the storage-layout note above. Elements span
+    ///         two slots each.
+    Pair[] public pairs;
+
+    /// @notice Membership index for `pairs`. Slot 1. Stores `index + 1`, so 0 means "not present".
+    /// @dev    Nested rather than a single `bytes32` key over `keccak256(abi.encode(from, to))`:
+    ///         the nested form is measurably cheaper (Solidity computes mapping slots in scratch
+    ///         space, while `abi.encode` pays for memory allocation — ~355 gas per SSTORE,
+    ///         ~379 per SLOAD), and its generated getter takes the two addresses directly instead
+    ///         of forcing every off-chain caller to reproduce a hashing scheme. It cannot be a
+    ///         `bool`: `_rmPair` needs the element's array position.
+    mapping(address => mapping(address => uint256)) public pairIndex;
+
+    /// @notice Senders whose transactions are all eligible, whatever the recipient. Slot 2 — see
+    ///         the storage-layout note above.
+    address[] public fromWildcards;
+
+    /// @notice Membership index for `fromWildcards`. Slot 3. Stores `index + 1`.
+    mapping(address => uint256) public fromWildcardIndex;
+
+    /// @notice Recipients that make any transaction to them eligible, whatever the sender. Slot 4
+    ///         — see the storage-layout note above.
+    address[] public toWildcards;
+
+    /// @notice Membership index for `toWildcards`. Slot 5. Stores `index + 1`.
+    mapping(address => uint256) public toWildcardIndex;
+
+    /// @notice Which storage layout this contract was deployed with — [`LAYOUT_VERSION`]. Slot 6.
+    /// @dev    **Appended after every array on purpose**, so bumping it can never shift the slots
+    ///         op-reth reads.
+    ///
+    ///         It exists because the has-code check on the sequencer side proves only that
+    ///         *something* is deployed at the configured address, not that it is this contract at
+    ///         this layout. Without a marker, a version skew in either direction is silent and
+    ///         actively wrong rather than merely stale:
+    ///
+    ///         * a binary built for the previous cross-product layout reads `pairs` with a
+    ///           one-slot stride, so it takes alternating `from`/`to` halves for a sender list;
+    ///         * a binary built for this layout, pointed at the previous contract, reads that
+    ///           contract's *recipient* list out of slot 2 and installs it as **sender
+    ///           wildcards** — authorizing traffic governance never approved.
+    ///
+    ///         A storage variable rather than a `constant`: constants live in code, and op-reth
+    ///         reads state, not code. One SSTORE at deployment buys a one-slot check at every cold
+    ///         start.
+    uint256 public layoutVersion;
+
+    /// @notice Maximum number of rules a single `updatePreconfs` call may touch, summed across
+    ///         both arguments.
+    /// @dev    Adding an exact pair is the most expensive per-rule operation (two array slots plus
+    ///         one mapping slot, against two slots for a wildcard), so bounding the *total* count
+    ///         by the pair-add capacity makes `MAX_BATCH * gas(addPair)` a strict upper bound on
+    ///         the call's gas regardless of how the batch is composed. That keeps the relayed call
+    ///         inside the `minGasLimit` governance supplies and well inside the L2 block gas limit.
+    ///         Oversized batches revert before any SSTORE, so they are cheap and change nothing.
+    ///
+    ///         **Measured**, by `test_gas_maxBatchOfPairAdds` / `..OfWildcardAdds`:
+    ///
+    ///           pair add      68,018 gas   ->  330 of them = 22,446,092
+    ///           wildcard add  45,680 gas   ->  330 of them = 15,074,717
+    ///
+    ///         330 is calibrated against the same ~23M ceiling the previous cross-product version
+    ///         used (its 500 address-adds at 45,680 each came to 22.84M). Raising this constant
+    ///         means re-running those two tests, not re-deriving from the ratio.
+    uint256 public constant MAX_BATCH = 330;
+
+    /// @notice The layout this contract declares, written to [`layoutVersion`] at construction.
+    /// @dev    Bump on **any** change to the storage layout above — a reordering, an insertion, or
+    ///         a change to `Pair`'s field count. op-reth pins the same number in
+    ///         `mantle-reth/crates/preconf/src/whitelist.rs` (`EXPECTED_LAYOUT_VERSION`) and
+    ///         refuses to start against anything else, so the two move together or the node says
+    ///         so at boot instead of mis-reading state for the rest of its life.
+    ///
+    ///         `1` was the cross-product layout (`preconfFromList` / `preconfToList`); it never
+    ///         wrote this slot, so it reads back as `0` and is rejected on the same path.
+    uint256 public constant LAYOUT_VERSION = 2;
+
+    /// @notice Emitted whenever the allowlist changes. op-reth watches for this (topic0
+    ///         `keccak256("WhitelistUpdated(uint256,uint256,uint256)")`) and re-reads all three
+    ///         sets from state.
+    /// @dev    Changing this signature changes topic0 and would silently stop the sequencer from
+    ///         refreshing — it would keep running on whatever it read at bootstrap, with no error.
+    ///         The Rust constant is `WHITELIST_UPDATED_TOPIC0` in
+    ///         `mantle-reth/crates/preconf/src/whitelist.rs`; both sides assert the same literal.
+    /// @param pairCount         Number of exact rules after the update.
+    /// @param fromWildcardCount Number of sender wildcards after the update.
+    /// @param toWildcardCount   Number of recipient wildcards after the update.
+    event WhitelistUpdated(uint256 pairCount, uint256 fromWildcardCount, uint256 toWildcardCount);
+
+    /// @notice Seeds the initial allowlist so the contract is usable the moment it is deployed,
+    ///         with no follow-up governance message required.
+    /// @dev    Deliberately not subject to `MAX_BATCH`: deployment gas is bounded by whoever sends
+    ///         the deployment transaction, not by a relayed message's `minGasLimit`.
+    /// @param _authorizedL1 L1 governance address permitted to update the allowlist.
+    /// @param _initPairs    Initial rules, in the same three forms `updatePreconfs` accepts.
+    constructor(address _authorizedL1, Pair[] memory _initPairs) {
+        require(_authorizedL1 != address(0), "PreconfWhitelist: authorized L1 sender is the zero address");
+        AUTHORIZED_L1 = _authorizedL1;
+        layoutVersion = LAYOUT_VERSION;
+        for (uint256 i = 0; i < _initPairs.length; i++) {
+            _apply(_initPairs[i].from, _initPairs[i].to, true);
+        }
+        emit WhitelistUpdated(pairs.length, fromWildcards.length, toWildcards.length);
+    }
+
+    /// @notice Restricts a function to cross-domain messages sent by `AUTHORIZED_L1`.
+    /// @dev    Two independent checks, both required:
+    ///         (1) the caller is the L2CrossDomainMessenger, proving we were reached by a relayed
+    ///             cross-domain message rather than by a deposit aimed straight at this contract;
+    ///         (2) the original L1 sender is `AUTHORIZED_L1`, rejecting relayed messages from any
+    ///             other L1 caller. Forgery is prevented upstream by the messenger's own gate,
+    ///             which only accepts deposits whose `from` is the aliased L1CrossDomainMessenger.
+    modifier onlyL1Gov() {
+        require(msg.sender == MESSENGER, "PreconfWhitelist: caller is not the messenger");
+        require(
+            L2CrossDomainMessenger(payable(MESSENGER)).xDomainMessageSender() == AUTHORIZED_L1,
+            "PreconfWhitelist: caller is not the authorized L1 sender"
+        );
+        _;
+    }
+
+    /// @notice Applies a batch of allowlist changes. Each `Pair` is routed by its zero halves:
+    ///
+    ///           (from != 0, to != 0)  ->  exact rule, `pairs`
+    ///           (from == 0, to != 0)  ->  recipient wildcard, `toWildcards`
+    ///           (from != 0, to == 0)  ->  sender wildcard, `fromWildcards`
+    ///           (from == 0, to == 0)  ->  reverts
+    ///
+    ///         The all-zero form would mean "every transaction is eligible". That capability is
+    ///         deliberately absent: turning preconf on for everything is the node operator's
+    ///         switch (`--preconf.all`), not governance's, and reverting also catches a governance
+    ///         script that shipped an uninitialized array element — which would otherwise vanish
+    ///         silently and surface later as "why is this rule not in effect".
+    ///
+    ///         Adds are applied before removes, so a rule present in both arguments ends up
+    ///         removed. Every individual operation is idempotent: adding a present rule or
+    ///         removing an absent one is a no-op rather than a revert, so a delta computed against
+    ///         slightly stale state still applies cleanly.
+    ///
+    ///         No normalization or deduplication happens across the three sets. `(A, B)` and
+    ///         `(A, 0)` may both be present; both match, and removing one leaves the other. Which
+    ///         of them expresses governance's intent is not something this contract can infer.
+    /// @param _add    Rules to authorize.
+    /// @param _remove Rules to revoke.
+    function updatePreconfs(Pair[] calldata _add, Pair[] calldata _remove) external onlyL1Gov {
+        require(_add.length + _remove.length <= MAX_BATCH, "PreconfWhitelist: batch too large");
+        for (uint256 i = 0; i < _add.length; i++) {
+            _apply(_add[i].from, _add[i].to, true);
+        }
+        for (uint256 i = 0; i < _remove.length; i++) {
+            _apply(_remove[i].from, _remove[i].to, false);
+        }
+        emit WhitelistUpdated(pairs.length, fromWildcards.length, toWildcards.length);
+    }
+
+    // ===== views =====
+    //
+    // Only paginated getters are provided. A full-list getter works right up until the list grows
+    // past the point where it does not, and its failure mode is a reverting call rather than a
+    // truncated result — a hard break for off-chain tooling, arriving at a moment governance
+    // chooses rather than one the caller controls. Paging makes that boundary an explicit
+    // parameter. op-reth is unaffected either way: it reads storage directly.
+
+    /// @notice Number of exact rules.
+    /// @return Length of `pairs`, i.e. the upper bound for `getPairs`'s `_offset`.
+    function pairsLength() external view returns (uint256) {
+        return pairs.length;
+    }
+
+    /// @notice Number of sender wildcards.
+    /// @return Length of `fromWildcards`, i.e. the upper bound for `getFromWildcards`'s `_offset`.
+    function fromWildcardsLength() external view returns (uint256) {
+        return fromWildcards.length;
+    }
+
+    /// @notice Number of recipient wildcards.
+    /// @return Length of `toWildcards`, i.e. the upper bound for `getToWildcards`'s `_offset`.
+    function toWildcardsLength() external view returns (uint256) {
+        return toWildcards.length;
+    }
+
+    /// @notice Returns up to `_limit` exact rules starting at `_offset`.
+    /// @dev    An out-of-range `_offset` returns an empty array and an over-long `_limit` is
+    ///         truncated, so a caller paging to the end never has to special-case the last page.
+    /// @param _offset Index of the first rule to return. Order is not stable across updates —
+    ///                `_rmPair` swaps the last element into the freed position.
+    /// @param _limit  Maximum number of rules to return.
+    /// @return out_ The requested page, shorter than `_limit` when fewer rules remain.
+    function getPairs(uint256 _offset, uint256 _limit) external view returns (Pair[] memory out_) {
+        uint256 len = pairs.length;
+        if (_offset >= len) return new Pair[](0);
+        uint256 n = len - _offset;
+        if (_limit < n) n = _limit;
+        out_ = new Pair[](n);
+        for (uint256 i = 0; i < n; i++) {
+            out_[i] = pairs[_offset + i];
+        }
+    }
+
+    /// @notice Returns up to `_limit` sender wildcards starting at `_offset`.
+    /// @param _offset Index of the first wildcard to return; at or past the end yields an empty
+    ///                array. Order is not stable across updates — `_rmAddr` swaps the last element
+    ///                into the freed position.
+    /// @param _limit  Maximum number to return, truncated to what remains after `_offset`.
+    /// @return The requested page.
+    function getFromWildcards(uint256 _offset, uint256 _limit) external view returns (address[] memory) {
+        return _page(fromWildcards, _offset, _limit);
+    }
+
+    /// @notice Returns up to `_limit` recipient wildcards starting at `_offset`.
+    /// @param _offset Index of the first wildcard to return; at or past the end yields an empty
+    ///                array. Order is not stable across updates — `_rmAddr` swaps the last element
+    ///                into the freed position.
+    /// @param _limit  Maximum number to return, truncated to what remains after `_offset`.
+    /// @return The requested page.
+    function getToWildcards(uint256 _offset, uint256 _limit) external view returns (address[] memory) {
+        return _page(toWildcards, _offset, _limit);
+    }
+
+    /// @notice The eligibility predicate itself: true if `_from -> _to` is allowed by **any** of the
+    ///         three sets. This is the question the sequencer answers per transaction; the three
+    ///         accessors below expose the individual terms.
+    /// @dev    A plain OR, matching the relation in the contract docs. No precedence and no deny
+    ///         list: revoking the exact pair `(A, B)` still leaves `A -> B` eligible while `A` is a
+    ///         sender wildcard.
+    ///
+    ///         Passing `address(0)` for `_to` yields the contract-creation answer without a special
+    ///         case. A creation has no recipient, so only a sender wildcard can authorize it — and
+    ///         since the zero address is a calldata-only marker that never reaches storage, both the
+    ///         pair term and the recipient term are necessarily false, leaving exactly
+    ///         `isFromWildcard(_from)`. The sequencer's own check
+    ///         (`Whitelist::is_eligible` in `mantle-reth/crates/preconf/src/classifier.rs`) reaches
+    ///         the same answer through an explicit `Option<Address>`.
+    /// @param _from Sender of the transaction.
+    /// @param _to   Recipient, or `address(0)` for a contract creation.
+    /// @return True if the transaction is eligible for the preconf fast path.
+    function isWhitelist(address _from, address _to) external view returns (bool) {
+        return pairIndex[_from][_to] != 0 || fromWildcardIndex[_from] != 0 || toWildcardIndex[_to] != 0;
+    }
+
+    /// @notice Returns true if `_from -> _to` is an exact rule. Does NOT consider wildcards — see
+    ///         `isFromWildcard` / `isToWildcard`, and the OR in the contract docs.
+    /// @param _from Sender half of the rule.
+    /// @param _to   Recipient half of the rule. Neither half is ever the zero address in storage,
+    ///              so a zero argument never matches.
+    /// @return True if the exact pair is present.
+    function isWhitelistPair(address _from, address _to) external view returns (bool) {
+        return pairIndex[_from][_to] != 0;
+    }
+
+    /// @notice Returns true if every transaction from `_addr` is eligible.
+    /// @param _addr Sender to test. The zero address is never stored, so it never matches.
+    /// @return True if `_addr` is a sender wildcard.
+    function isFromWildcard(address _addr) external view returns (bool) {
+        return fromWildcardIndex[_addr] != 0;
+    }
+
+    /// @notice Returns true if every transaction to `_addr` is eligible.
+    /// @param _addr Recipient to test. The zero address is never stored, so it never matches.
+    /// @return True if `_addr` is a recipient wildcard.
+    function isToWildcard(address _addr) external view returns (bool) {
+        return toWildcardIndex[_addr] != 0;
+    }
+
+    // ===== internals =====
+
+    /// @notice Routes one rule to its set and adds or removes it. The single place the three
+    ///         `Pair` forms are interpreted, so the constructor and `updatePreconfs` cannot
+    ///         disagree about them.
+    /// @dev    Takes the halves as value-type arguments rather than a `Pair`, so the same body
+    ///         serves the constructor's `memory` array and `updatePreconfs`'s `calldata` one.
+    /// @param _from  Sender half, or the zero address to route this rule to `toWildcards`.
+    /// @param _to    Recipient half, or the zero address to route it to `fromWildcards`.
+    /// @param _isAdd True to authorize the rule, false to revoke it.
+    function _apply(address _from, address _to, bool _isAdd) internal {
+        require(_from != address(0) || _to != address(0), "PreconfWhitelist: pair is all-zero");
+        if (_from == address(0)) {
+            if (_isAdd) _addAddr(toWildcards, toWildcardIndex, _to);
+            else _rmAddr(toWildcards, toWildcardIndex, _to);
+        } else if (_to == address(0)) {
+            if (_isAdd) _addAddr(fromWildcards, fromWildcardIndex, _from);
+            else _rmAddr(fromWildcards, fromWildcardIndex, _from);
+        } else {
+            if (_isAdd) _addPair(_from, _to);
+            else _rmPair(_from, _to);
+        }
+    }
+
+    /// @notice Appends `(_from, _to)` to `pairs` and records its position. No-op if already
+    ///         present. Both halves are known non-zero — `_apply` routed us here precisely
+    ///         because of that.
+    /// @param _from Sender half, known non-zero.
+    /// @param _to   Recipient half, known non-zero.
+    function _addPair(address _from, address _to) internal {
+        if (pairIndex[_from][_to] != 0) return;
+        pairs.push(Pair({ from: _from, to: _to }));
+        pairIndex[_from][_to] = pairs.length;
+    }
+
+    /// @notice Removes `(_from, _to)` from `pairs` by swapping in the final element and popping,
+    ///         keeping `pairIndex` in step. No-op if absent. Order is not preserved; the sequencer
+    ///         treats this as a set.
+    /// @dev    Removing the last element is the degenerate case of the same code: the swap writes
+    ///         the element over itself, the index write restores it, and the `delete` below then
+    ///         clears it for good.
+    /// @param _from Sender half of the rule to revoke.
+    /// @param _to   Recipient half of the rule to revoke.
+    function _rmPair(address _from, address _to) internal {
+        uint256 idx = pairIndex[_from][_to];
+        if (idx == 0) return;
+        uint256 i = idx - 1;
+        Pair memory last = pairs[pairs.length - 1];
+        pairs[i] = last;
+        pairIndex[last.from][last.to] = i + 1;
+        pairs.pop();
+        delete pairIndex[_from][_to];
+    }
+
+    /// @notice Appends `_addr` to `_list` and records its position in `_idxMap`. No-op if already
+    ///         present. `_addr` is known non-zero: `_apply` only routes here when the *other* half
+    ///         was the zero marker, and it rejects the all-zero form outright. Nothing may write a
+    ///         zero entry — an unset array element reads back as the zero address on the sequencer
+    ///         side, so a stored zero would be indistinguishable from a slot that was never
+    ///         written.
+    /// @param _list   Wildcard array to append to — `fromWildcards` or `toWildcards`.
+    /// @param _idxMap That array's membership index, written in the same call to stay in step.
+    /// @param _addr   Address to authorize, known non-zero.
+    function _addAddr(address[] storage _list, mapping(address => uint256) storage _idxMap, address _addr) internal {
+        if (_idxMap[_addr] != 0) return;
+        _list.push(_addr);
+        _idxMap[_addr] = _list.length;
+    }
+
+    /// @notice Removes `_addr` from `_list` by swapping in the final element and popping, keeping
+    ///         `_idxMap` in step. No-op if `_addr` is absent.
+    /// @param _list   Wildcard array to remove from — `fromWildcards` or `toWildcards`.
+    /// @param _idxMap That array's membership index, rewritten for the swapped-in element.
+    /// @param _addr   Address to revoke.
+    function _rmAddr(address[] storage _list, mapping(address => uint256) storage _idxMap, address _addr) internal {
+        uint256 idx = _idxMap[_addr];
+        if (idx == 0) return;
+        uint256 i = idx - 1;
+        address last = _list[_list.length - 1];
+        _list[i] = last;
+        _idxMap[last] = i + 1;
+        _list.pop();
+        delete _idxMap[_addr];
+    }
+
+    /// @notice Shared paging body for the two wildcard getters.
+    /// @param _list   Wildcard array to page over.
+    /// @param _offset Index of the first element to return; at or past the end yields an empty
+    ///                array.
+    /// @param _limit  Maximum number to return, truncated to what remains after `_offset`.
+    /// @return out_ The requested page.
+    function _page(
+        address[] storage _list,
+        uint256 _offset,
+        uint256 _limit
+    )
+        internal
+        view
+        returns (address[] memory out_)
+    {
+        uint256 len = _list.length;
+        if (_offset >= len) return new address[](0);
+        uint256 n = len - _offset;
+        if (_limit < n) n = _limit;
+        out_ = new address[](n);
+        for (uint256 i = 0; i < n; i++) {
+            out_[i] = _list[_offset + i];
+        }
+    }
+}

--- a/packages/contracts-bedrock/src/L2/PreconfWhitelist.sol
+++ b/packages/contracts-bedrock/src/L2/PreconfWhitelist.sol
@@ -135,6 +135,24 @@ contract PreconfWhitelist {
     ///         start.
     uint256 public layoutVersion;
 
+    /// @notice Highest governance nonce this contract has executed. Slot 7. Starts at 0, so the
+    ///         first accepted message must carry a nonce of at least 1.
+    /// @dev    Exists to kill **stale replays**. A relayed message that fails lands in the
+    ///         L2CrossDomainMessenger's `failedMessages` mapping, from where *anyone* may replay it
+    ///         forever. Authorization survives the replay unchanged — the versioned hash binds the
+    ///         original L1 sender — but the *timing* does not: `updatePreconfs` carries a delta,
+    ///         and a delta computed against the allowlist of six months ago re-authorizes whatever
+    ///         governance has revoked since. The replayer picks the moment.
+    ///
+    ///         Only one failure mode actually produces a message that fails now and would succeed
+    ///         later: running out of gas. The two `require`s below (`batch too large`,
+    ///         `pair is all-zero`) are decided by the calldata alone, so a replay of one of those
+    ///         fails identically and is harmless.
+    ///
+    ///         Appended after `layoutVersion`, so it cannot shift the slots op-reth reads. Adding
+    ///         it is therefore **not** a layout change and must not bump [`LAYOUT_VERSION`].
+    uint256 public localNonce;
+
     /// @notice Maximum number of rules a single `updatePreconfs` call may touch, summed across
     ///         both arguments.
     /// @dev    Adding an exact pair is the most expensive per-rule operation (two array slots plus
@@ -146,8 +164,8 @@ contract PreconfWhitelist {
     ///
     ///         **Measured**, by `test_gas_maxBatchOfPairAdds` / `..OfWildcardAdds`:
     ///
-    ///           pair add      69,098 gas   ->  256 of them = 17,689,309
-    ///           wildcard add  46,647 gas   ->  256 of them = 11,941,833
+    ///           pair add      69,275 gas   ->  256 of them = 17,734,481
+    ///           wildcard add  46,824 gas   ->  256 of them = 11,987,007
     ///
     ///         What that has to fit in is **not** the L2 block gas limit — on Mantle that is orders
     ///         of magnitude larger and never binds. The binding constraint is on **L1**: governance
@@ -157,13 +175,20 @@ contract PreconfWhitelist {
     ///         at `maxResourceLimit` — 20,000,000 in `Constants.DEFAULT_RESOURCE_CONFIG`. So the
     ///         ceiling on the L2 execution governance can pay for is what survives `baseGas`:
     ///
-    ///           20,000,000  -  683,088 fixed overhead   (200k constant + 16,516 calldata bytes at
+    ///           20,000,000  -  683,664 fixed overhead   (200k constant + 16,548 calldata bytes at
     ///                                                    16+2 each + 800 + 40k + 90k + 55k)
-    ///                       =  19,316,912, then x 63/64  (the EIP-150 dynamic term)
-    ///                       =  19,015,085 of `_minGasLimit`
+    ///                       =  19,316,336, then x 63/64  (the EIP-150 dynamic term)
+    ///                       =  19,014,519 of `_minGasLimit`
     ///
-    ///         256 pair adds need 17,689,309 of that — **7% headroom**. Extrapolating the two
-    ///         measurements puts the hard ceiling near 276 rules, so 256 is the power of two just
+    ///         The exact boundary is the largest `_minGasLimit` satisfying
+    ///         `fixed + _minGasLimit * 64 / 63 <= 20,000,000`; multiplying the remainder by 63/64
+    ///         floors one gas low, so solve rather than scale if the figure ever has to be exact.
+    ///
+    ///         The 16,548 bytes are a full batch's `updatePreconfs` calldata: 4 selector + 32 for
+    ///         `_nonce` + two 32-byte offsets + a 32-byte length per array + 64 per rule.
+    ///
+    ///         256 pair adds need 17,734,481 of that — **6.7% headroom**. Extrapolating the
+    ///         measurements puts the hard ceiling at 275 rules, so 256 is the power of two just
     ///         below it. The headroom is not decoration: `maxResourceLimit` is a budget
     ///         *shared across every depositor in the L1 block*, so the 19M figure is the best case
     ///         of an otherwise-idle block. Buying near it is also expensive, since the target is
@@ -264,10 +289,36 @@ contract PreconfWhitelist {
     ///         transaction that sent it still succeeded. Governance must verify on L2 that the
     ///         update landed; a batch at or below [`MAX_BATCH`] is a necessary condition, not a
     ///         sufficient one.
+    ///
+    ///         That same failure path is why `_nonce` exists — a failed message is replayable by
+    ///         anyone, forever, and a stale delta re-authorizes what governance has since revoked.
+    ///         See [`localNonce`] for the threat and for the limit of what this guard covers.
+    ///
+    ///         The nonce is a plain parameter rather than something read from the messenger:
+    ///         `relayMessage`'s own `_nonce` is never stored and is not exposed to the target, and
+    ///         the target cannot reach the caller's calldata. Passing it explicitly is equivalent
+    ///         in strength — the versioned hash covers `_message` in full, so a replay must carry
+    ///         these exact bytes and cannot alter the nonce it was sent with.
+    ///
+    ///         It leads the parameter list to match the two frames this calldata travels inside —
+    ///         `relayMessage(uint256 _nonce, ...)` and `Hashing.hashCrossDomainMessageV1(uint256
+    ///         _nonce, ...)` both open with it — and because it is the first thing checked below.
+    /// @param _nonce  Governance-chosen sequence number, strictly greater than [`localNonce`].
+    ///                Gaps are fine — only the ordering matters — so this may be sourced from a
+    ///                dedicated counter or from `L1CrossDomainMessenger.messageNonce()`.
     /// @param _add    Rules to authorize.
     /// @param _remove Rules to revoke.
-    function updatePreconfs(Rule[] calldata _add, Rule[] calldata _remove) external onlyL1Gov {
+    function updatePreconfs(
+        uint256 _nonce,
+        Rule[] calldata _add,
+        Rule[] calldata _remove
+    )
+        external
+        onlyL1Gov
+    {
+        require(_nonce > localNonce, "PreconfWhitelist: stale nonce");
         require(_add.length + _remove.length <= MAX_BATCH, "PreconfWhitelist: batch too large");
+        localNonce = _nonce;
         for (uint256 i = 0; i < _add.length; i++) {
             _apply(_add[i].from, _add[i].to, true);
         }

--- a/packages/contracts-bedrock/src/L2/PreconfWhitelist.sol
+++ b/packages/contracts-bedrock/src/L2/PreconfWhitelist.sol
@@ -1,247 +1,87 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { L2CrossDomainMessenger } from "./L2CrossDomainMessenger.sol";
+import { AddressAliasHelper } from "../vendor/AddressAliasHelper.sol";
+
+// Backing value for `PreconfWhitelist.MAX_BATCH`, declared at file level so `PreconfWhitelistGov`
+// on L1 can import the same constant. A contract's `constant` is not reachable as
+// `PreconfWhitelist.MAX_BATCH` in solc 0.8.15, so without this the L1 cap would be a copy.
+uint256 constant PRECONF_MAX_BATCH = 256;
 
 /// @title PreconfWhitelist
-/// @notice Authoritative on-chain storage for the sequencer's preconfirmation allowlist. The
-///         sequencer (op-reth) mirrors these three sets into memory and consults them when
-///         deciding whether a transaction is eligible for the preconf fast path.
-///
-///         Eligibility is an **explicit `(from, to)` relation**, not a cross product:
-///
-///           eligible(from, to)  <=>  isExactPair(from, to)
-///                                ||  isFromWildcard(from)
-///                                ||  isToWildcard(to)
-///
-///         The predicate is a plain OR with no precedence and no deny list. In particular,
-///         removing `(A, X)` from the exact set does NOT stop `A -> X` if `A` is still a from
-///         wildcard; the wildcard has to be removed too.
-///
-///         Updates may only originate from a single authorized L1 address (the governance Safe),
-///         relayed through the standard OP-Stack L1->L2 CrossDomainMessenger channel. No L1
-///         contract is deployed for this: governance calls `L1CrossDomainMessenger.sendMessage`
-///         directly, which becomes an OptimismPortal deposit and lands here via
-///         `L2CrossDomainMessenger.relayMessage`.
-///
-///         This is a regular deployed contract, NOT a predeploy — it is deployed with a normal L2
-///         transaction and its address is passed to op-reth via `--preconf.whitelist-address`.
-///
-/// @dev    A note on vocabulary, because one word used to carry two meanings. A [`Rule`] is the
-///         **wire format**: the struct governance submits, in any of the three forms below. An
-///         **exact pair** is one of the three *sets* — the rules whose halves are both non-zero,
-///         held in [`exactPairs`]. Every exact pair is a rule; a wildcard is a rule too, but not
-///         an exact pair. Identifiers follow that split: `Rule` and `getAllRules` speak about the
-///         wire format, everything spelled `exactPair*` speaks about the one set.
-///
-///         STORAGE LAYOUT IS LOAD-BEARING. op-reth reads `exactPairs` (slot 0), `fromWildcards`
-///         (slot 2) and `toWildcards` (slot 4) directly out of state — it never calls the view
-///         functions below, because the classifier's eligibility check is a synchronous,
-///         no-IO hot path that reads an in-memory mirror. The six state variables must therefore
-///         keep their exact order and slot assignment. Do NOT insert, reorder, or remove state
-///         variables, and do not add a base contract that declares storage. The Rust side pins the
-///         same numbers in `mantle-reth/crates/preconf/src/whitelist.rs`
-///         (`PAIRS_SLOT` / `FROM_WILDCARDS_SLOT` / `TO_WILDCARDS_SLOT`);
-///         `test/PreconfWhitelist.t.sol` asserts the layout so a drift breaks CI here first.
-///         `layoutVersion` (slot 6) is the runtime guard for the same coupling — see its docs.
-///
-///         Note especially that a `Rule` element spans **two** slots: two addresses are 40 bytes,
-///         so they cannot share one. `exactPairs[i].from` lives at `keccak256(0) + 2i` and
-///         `exactPairs[i].to` at `keccak256(0) + 2i + 1`. The Rust reader depends on that stride.
-///
-///         Renaming anything below is safe for op-reth as long as the *declaration order* holds:
-///         the Rust side binds no view function and reads slots by number, and the sole ABI
-///         couplings are the `updatePreconfs` selector and the `WhitelistUpdated` topic0, neither
-///         of which depends on a parameter or variable name. A rename must NOT bump
-///         [`LAYOUT_VERSION`] — nothing moved.
+/// @notice Preconf fast-path allowlist, governed only from `authorizedL1` by direct portal deposit.
+///         LAYOUT IS LOAD-BEARING: op-reth reads slots 0/2/4/6 and a `Rule` spans two; never reorder.
 contract PreconfWhitelist {
-    /// @notice One allowlist rule, in the form governance submits it. Both halves non-zero means an
-    ///         exact match; exactly one zero half means a wildcard on the other side (see
-    ///         `updatePreconfs`). Stored entries in `exactPairs` always have both halves non-zero —
-    ///         the zero address is a calldata-only marker and never reaches storage.
+    /// @notice One allowlist rule as governance submits it. Both halves non-zero is an exact pair;
+    ///         exactly one zero half is a wildcard on the other side. The zero address is a
+    ///         calldata-only routing marker and never reaches storage.
     struct Rule {
         address from;
         address to;
     }
 
-    /// @notice The L2CrossDomainMessenger predeploy — the only permitted direct caller of
-    ///         `updatePreconfs`. Cross-domain messages are relayed to us through it.
-    /// @dev    Held as an `address` because a cast to a contract type is not a compile-time
-    ///         constant; the cast happens at the call site (same as `CrossDomainOwnable2`).
-    ///         Spelled as a literal rather than `Predeploys.L2_CROSS_DOMAIN_MESSENGER` because
-    ///         solc 0.8.15 rejects a library constant in a constant initializer. There is no
-    ///         explicit `assertEq` pinning the two: `MESSENGER` is `internal` and unreachable from
-    ///         a test, so such an assertion would compare two constants and say nothing about this
-    ///         contract. Equality is proven implicitly instead — `test/PreconfWhitelist.t.sol`
-    ///         declares its messenger *as* that predeploy, and the first gate below admits only
-    ///         `msg.sender == MESSENGER`, so every passing governance call in that file depends on
-    ///         it. See the note on `test_updatePreconfs_notMessenger_reverts`.
-    address internal constant MESSENGER = 0x4200000000000000000000000000000000000007;
-
-    /// @notice The one L1 address permitted to govern this allowlist (the governance Safe), stored
-    ///         unaliased. This is the address that calls `L1CrossDomainMessenger.sendMessage`, as
-    ///         reported by `xDomainMessageSender()` during relay.
-    /// @dev    Immutable, so it occupies no storage slot and cannot shift the layout below.
-    ///         Rotating the governance Safe therefore requires redeploying this contract and
-    ///         repointing op-reth at the new address.
-    ///
-    ///         The codebase-wide ban on immutables exists for proxied contracts, where an immutable
-    ///         set at implementation-deploy time diverges from the proxy. This contract is neither
-    ///         proxied nor a predeploy (see the note above), and occupying no slot is exactly what
-    ///         keeps the load-bearing layout below out of reach of a governance-address change.
-    // nosemgrep: sol-safety-no-immutable-variables
-    address public immutable AUTHORIZED_L1;
-
-    /// @notice Exact `(from, to)` rules — the rules with **both halves non-zero**, as distinct from
-    ///         the two wildcard sets below. Slot 0 — see the storage-layout note above. Elements
-    ///         span two slots each.
+    /// @notice Exact `(from, to)` rules — both halves non-zero. Slot 0, two slots per element.
     Rule[] public exactPairs;
 
-    /// @notice Membership index for `exactPairs`. Slot 1. Stores `index + 1`, so 0 means "not
-    ///         present".
-    /// @dev    Nested rather than a single `bytes32` key over `keccak256(abi.encode(from, to))`:
-    ///         the nested form is measurably cheaper (Solidity computes mapping slots in scratch
-    ///         space, while `abi.encode` pays for memory allocation — ~355 gas per SSTORE,
-    ///         ~379 per SLOAD), and its generated getter takes the two addresses directly instead
-    ///         of forcing every off-chain caller to reproduce a hashing scheme. It cannot be a
-    ///         `bool`: `_rmExactPair` needs the element's array position.
+    /// @notice Membership index for `exactPairs`. Slot 1. Stores `index + 1`, so 0 means absent.
+    ///         Nested rather than keyed on a hash of the pair: cheaper, and the generated getter
+    ///         takes two addresses. Not a `bool` — `_rmExactPair` needs the array position.
     mapping(address => mapping(address => uint256)) public exactPairIndex;
 
-    /// @notice Senders whose transactions are all eligible, whatever the recipient. Slot 2 — see
-    ///         the storage-layout note above.
+    /// @notice Senders whose transactions are all eligible, whatever the recipient. Slot 2.
     address[] public fromWildcards;
 
     /// @notice Membership index for `fromWildcards`. Slot 3. Stores `index + 1`.
     mapping(address => uint256) public fromWildcardIndex;
 
-    /// @notice Recipients that make any transaction to them eligible, whatever the sender. Slot 4
-    ///         — see the storage-layout note above.
+    /// @notice Recipients that make any transaction to them eligible, whatever the sender. Slot 4.
     address[] public toWildcards;
 
     /// @notice Membership index for `toWildcards`. Slot 5. Stores `index + 1`.
     mapping(address => uint256) public toWildcardIndex;
 
-    /// @notice Which storage layout this contract was deployed with — [`LAYOUT_VERSION`]. Slot 6.
-    /// @dev    **Appended after every array on purpose**, so bumping it can never shift the slots
-    ///         op-reth reads.
-    ///
-    ///         It exists because the has-code check on the sequencer side proves only that
-    ///         *something* is deployed at the configured address, not that it is this contract at
-    ///         this layout. Without a marker, a version skew in either direction is silent and
-    ///         actively wrong rather than merely stale:
-    ///
-    ///         * a binary built for the previous cross-product layout reads `exactPairs` with a
-    ///           one-slot stride, so it takes alternating `from`/`to` halves for a sender list;
-    ///         * a binary built for this layout, pointed at the previous contract, reads that
-    ///           contract's *recipient* list out of slot 2 and installs it as **sender
-    ///           wildcards** — authorizing traffic governance never approved.
-    ///
-    ///         A storage variable rather than a `constant`: constants live in code, and op-reth
-    ///         reads state, not code. One SSTORE at deployment buys a one-slot check at every cold
-    ///         start.
+    /// @notice Which storage layout this deployment uses — [`LAYOUT_VERSION`]. Slot 6. Appended
+    ///         after every array so bumping it cannot shift them. State, not a constant, because
+    ///         op-reth reads state; it refuses to start on a version it cannot read.
     uint256 public layoutVersion;
 
-    /// @notice Highest governance nonce this contract has executed. Slot 7. Starts at 0, so the
-    ///         first accepted message must carry a nonce of at least 1.
-    /// @dev    Exists to kill **stale replays**. A relayed message that fails lands in the
-    ///         L2CrossDomainMessenger's `failedMessages` mapping, from where *anyone* may replay it
-    ///         forever. Authorization survives the replay unchanged — the versioned hash binds the
-    ///         original L1 sender — but the *timing* does not: `updatePreconfs` carries a delta,
-    ///         and a delta computed against the allowlist of six months ago re-authorizes whatever
-    ///         governance has revoked since. The replayer picks the moment.
-    ///
-    ///         Only one failure mode actually produces a message that fails now and would succeed
-    ///         later: running out of gas. The two `require`s below (`batch too large`,
-    ///         `pair is all-zero`) are decided by the calldata alone, so a replay of one of those
-    ///         fails identically and is harmless.
-    ///
-    ///         Appended after `layoutVersion`, so it cannot shift the slots op-reth reads. Adding
-    ///         it is therefore **not** a layout change and must not bump [`LAYOUT_VERSION`].
-    uint256 public localNonce;
+    /// @notice The one L1 address permitted to govern, stored **unaliased**. Slot 7. Must be an L1
+    ///         contract — the portal aliases only contracts, so an EOA is locked out. Declared after
+    ///         `layoutVersion`: at the top it would take slot 0 and shift every array.
+    address public authorizedL1;
 
-    /// @notice Maximum number of rules a single `updatePreconfs` call may touch, summed across
-    ///         both arguments.
-    /// @dev    Adding an exact pair is the most expensive per-rule operation (two array slots plus
-    ///         one mapping slot, against one array slot plus one mapping slot for a wildcard), so
-    ///         bounding the *total* count by the exact-pair-add capacity makes
-    ///         `MAX_BATCH * gas(_addExactPair)` a strict bound on the call's gas regardless of how
-    ///         the batch is composed. Oversized batches revert before any SSTORE, so they are cheap
-    ///         and change nothing.
-    ///
-    ///         **Measured**, by `test_gas_maxBatchOfPairAdds` / `..OfWildcardAdds`:
-    ///
-    ///           pair add      69,275 gas   ->  256 of them = 17,734,481
-    ///           wildcard add  46,824 gas   ->  256 of them = 11,987,007
-    ///
-    ///         What that has to fit in is **not** the L2 block gas limit — on Mantle that is orders
-    ///         of magnitude larger and never binds. The binding constraint is on **L1**: governance
-    ///         reaches us through `L1CrossDomainMessenger.sendMessage`, which asks
-    ///         `OptimismPortal.depositTransaction` for `baseGas(_message, _minGasLimit)` gas, and
-    ///         that call is `metered`. `ResourceMetering` caps the deposit gas bought per L1 block
-    ///         at `maxResourceLimit` — 20,000,000 in `Constants.DEFAULT_RESOURCE_CONFIG`. So the
-    ///         ceiling on the L2 execution governance can pay for is what survives `baseGas`:
-    ///
-    ///           20,000,000  -  683,664 fixed overhead   (200k constant + 16,548 calldata bytes at
-    ///                                                    16+2 each + 800 + 40k + 90k + 55k)
-    ///                       =  19,316,336, then x 63/64  (the EIP-150 dynamic term)
-    ///                       =  19,014,519 of `_minGasLimit`
-    ///
-    ///         The exact boundary is the largest `_minGasLimit` satisfying
-    ///         `fixed + _minGasLimit * 64 / 63 <= 20,000,000`; multiplying the remainder by 63/64
-    ///         floors one gas low, so solve rather than scale if the figure ever has to be exact.
-    ///
-    ///         The 16,548 bytes are a full batch's `updatePreconfs` calldata: 4 selector + 32 for
-    ///         `_nonce` + two 32-byte offsets + a 32-byte length per array + 64 per rule.
-    ///
-    ///         256 pair adds need 17,734,481 of that — **6.7% headroom**. Extrapolating the
-    ///         measurements puts the hard ceiling at 275 rules, so 256 is the power of two just
-    ///         below it. The headroom is not decoration: `maxResourceLimit` is a budget
-    ///         *shared across every depositor in the L1 block*, so the 19M figure is the best case
-    ///         of an otherwise-idle block. Buying near it is also expensive, since the target is
-    ///         `maxResourceLimit / elasticityMultiplier` = 2,000,000 and the deposit base fee climbs
-    ///         against that target.
-    ///
-    ///         Raising this constant means re-running those two tests and re-deriving the ceiling
-    ///         above, not scaling from the ratio. Lowering `maxResourceLimit` on L1 lowers the
-    ///         ceiling too, and nothing here would notice — see the warning on `updatePreconfs`.
-    uint256 public constant MAX_BATCH = 256;
+    /// @notice Maximum rules one `updatePreconfs` may touch, summed across both arguments. Sized on
+    ///         a pair add (68,044 gas): 256 need 17,419,375 of the 19,714,744 a deposit can buy
+    ///         (20,000,000 less 285,256 intrinsic). Ceiling is 289; re-measure before raising.
+    uint256 public constant MAX_BATCH = PRECONF_MAX_BATCH;
 
-    /// @notice The layout this contract declares, written to [`layoutVersion`] at construction.
-    /// @dev    Bump on **any** change to the storage layout above — a reordering, an insertion, or
-    ///         a change to `Rule`'s field count. Renaming a variable is not such a change; the
-    ///         layout is positional. op-reth pins the same number in
-    ///         `mantle-reth/crates/preconf/src/whitelist.rs` (`EXPECTED_LAYOUT_VERSION`) and
-    ///         refuses to start against anything else, so the two move together or the node says
-    ///         so at boot instead of mis-reading state for the rest of its life.
-    ///
-    ///         `1` was the cross-product layout (`preconfFromList` / `preconfToList`); it never
-    ///         wrote this slot, so it reads back as `0` and is rejected on the same path.
+    /// @notice The layout this contract declares, written to [`layoutVersion`] at construction. Bump
+    ///         on any positional change to the storage above; a rename is not one. op-reth pins the
+    ///         same number as `EXPECTED_LAYOUT_VERSION` and refuses anything else.
     uint256 public constant LAYOUT_VERSION = 2;
 
-    /// @notice Emitted whenever the allowlist changes. op-reth watches for this (topic0
-    ///         `keccak256("WhitelistUpdated(uint256,uint256,uint256)")`) and re-reads all three
-    ///         sets from state.
-    /// @dev    Changing this signature changes topic0 and would silently stop the sequencer from
-    ///         refreshing — it would keep running on whatever it read at bootstrap, with no error.
-    ///         The Rust constant is `WHITELIST_UPDATED_TOPIC0` in
-    ///         `mantle-reth/crates/preconf/src/whitelist.rs`; both sides assert the same literal.
-    ///         Parameter *names* are not part of the signature, so renaming them is free.
+    /// @notice Emitted whenever the allowlist changes; op-reth watches topic0 to trigger a re-read.
+    ///         Changing this signature moves topic0 and silently stops the sequencer refreshing.
+    ///         `WHITELIST_UPDATED_TOPIC0` pins the same literal; parameter names are not part of it.
     /// @param exactPairCount    Number of exact rules after the update.
     /// @param fromWildcardCount Number of sender wildcards after the update.
     /// @param toWildcardCount   Number of recipient wildcards after the update.
     event WhitelistUpdated(uint256 exactPairCount, uint256 fromWildcardCount, uint256 toWildcardCount);
 
-    /// @notice Seeds the initial allowlist so the contract is usable the moment it is deployed,
-    ///         with no follow-up governance message required.
-    /// @dev    Deliberately not subject to `MAX_BATCH`: deployment gas is bounded by whoever sends
-    ///         the deployment transaction, not by a relayed message's `minGasLimit`.
+    /// @notice Emitted when [`authorizedL1`] is rotated, carrying both ends — the replaced value is
+    ///         the only record of who authorized the replacement. op-reth does not watch this.
+    /// @param previousAuthorizedL1 The address permitted to govern until this call.
+    /// @param newAuthorizedL1      The address permitted to govern from now on.
+    event AuthorizedL1Updated(address indexed previousAuthorizedL1, address indexed newAuthorizedL1);
+
+    /// @notice Seeds the allowlist so the contract is usable the moment it is deployed. Not subject
+    ///         to `MAX_BATCH` — deployment gas is bounded by the deployer, not by a relayed message.
     /// @param _authorizedL1 L1 governance address permitted to update the allowlist.
-    /// @param _initRules    Initial rules, in the same three forms `updatePreconfs` accepts. A
-    ///                      `getAllRules()` reading from an existing deployment can be passed here
-    ///                      verbatim to clone its allowlist.
+    /// @param _initRules    Initial rules, in the three forms `updatePreconfs` accepts. A
+    ///                      `getAllRules()` result is valid here verbatim, which is how a clone works.
     constructor(address _authorizedL1, Rule[] memory _initRules) {
         require(_authorizedL1 != address(0), "PreconfWhitelist: authorized L1 sender is the zero address");
-        AUTHORIZED_L1 = _authorizedL1;
+        authorizedL1 = _authorizedL1;
         layoutVersion = LAYOUT_VERSION;
         for (uint256 i = 0; i < _initRules.length; i++) {
             _apply(_initRules[i].from, _initRules[i].to, true);
@@ -249,75 +89,34 @@ contract PreconfWhitelist {
         emit WhitelistUpdated(exactPairs.length, fromWildcards.length, toWildcards.length);
     }
 
-    /// @notice Restricts a function to cross-domain messages sent by `AUTHORIZED_L1`.
-    /// @dev    Two independent checks, both required:
-    ///         (1) the caller is the L2CrossDomainMessenger, proving we were reached by a relayed
-    ///             cross-domain message rather than by a deposit aimed straight at this contract;
-    ///         (2) the original L1 sender is `AUTHORIZED_L1`, rejecting relayed messages from any
-    ///             other L1 caller. Forgery is prevented upstream by the messenger's own gate,
-    ///             which only accepts deposits whose `from` is the aliased L1CrossDomainMessenger.
+    /// @notice Restricts a function to deposits originated on L1 by [`authorizedL1`]. Comparing the
+    ///         alias-UNDONE sender keeps `authorizedL1` human-checkable and closes impersonation: a
+    ///         raw compare would let any L1 contract speak for the same address on L2.
     modifier onlyL1Gov() {
-        require(msg.sender == MESSENGER, "PreconfWhitelist: caller is not the messenger");
         require(
-            L2CrossDomainMessenger(payable(MESSENGER)).xDomainMessageSender() == AUTHORIZED_L1,
+            AddressAliasHelper.undoL1ToL2Alias(msg.sender) == authorizedL1,
             "PreconfWhitelist: caller is not the authorized L1 sender"
         );
         _;
     }
 
-    /// @notice Applies a batch of allowlist changes. Each `Rule` is routed by its zero halves:
-    ///
-    ///           (from != 0, to != 0)  ->  exact rule, `exactPairs`
-    ///           (from == 0, to != 0)  ->  recipient wildcard, `toWildcards`
-    ///           (from != 0, to == 0)  ->  sender wildcard, `fromWildcards`
-    ///           (from == 0, to == 0)  ->  reverts
-    ///
-    ///         The all-zero form would mean "every transaction is eligible". That capability is
-    ///         deliberately absent: turning preconf on for everything is the node operator's
-    ///         switch (`--preconf.all`), not governance's, and reverting also catches a governance
-    ///         script that shipped an uninitialized array element — which would otherwise vanish
-    ///         silently and surface later as "why is this rule not in effect".
-    ///
-    ///         Adds are applied before removes, so a rule present in both arguments ends up
-    ///         removed. Every individual operation is idempotent: adding a present rule or
-    ///         removing an absent one is a no-op rather than a revert, so a delta computed against
-    ///         slightly stale state still applies cleanly.
-    ///
-    ///         No normalization or deduplication happens across the three sets. `(A, B)` and
-    ///         `(A, 0)` may both be present; both match, and removing one leaves the other. Which
-    ///         of them expresses governance's intent is not something this contract can infer.
-    /// @dev    [`MAX_BATCH`] bounds this call's gas, but the matching *supply* of gas is an L1-side
-    ///         decision this contract cannot see or check: governance picks `_minGasLimit` when it
-    ///         calls `sendMessage`, and the portal's `maxResourceLimit` caps what that may be. If
-    ///         either is too small, the relayed call runs out of gas inside
-    ///         `L2CrossDomainMessenger.relayMessage`, which records the message as failed rather
-    ///         than reverting the block — so the allowlist silently stays as it was, and the L1
-    ///         transaction that sent it still succeeded. Governance must verify on L2 that the
-    ///         update landed; a batch at or below [`MAX_BATCH`] is a necessary condition, not a
-    ///         sufficient one.
-    ///
-    ///         That same failure path is why `_nonce` exists — a failed message is replayable by
-    ///         anyone, forever, and a stale delta re-authorizes what governance has since revoked.
-    ///         See [`localNonce`] for the threat and for the limit of what this guard covers.
-    ///
-    ///         The nonce is a plain parameter rather than something read from the messenger:
-    ///         `relayMessage`'s own `_nonce` is never stored and is not exposed to the target, and
-    ///         the target cannot reach the caller's calldata. Passing it explicitly is equivalent
-    ///         in strength — the versioned hash covers `_message` in full, so a replay must carry
-    ///         these exact bytes and cannot alter the nonce it was sent with.
-    ///
-    ///         It leads the parameter list to match the two frames this calldata travels inside —
-    ///         `relayMessage(uint256 _nonce, ...)` and `Hashing.hashCrossDomainMessageV1(uint256
-    ///         _nonce, ...)` both open with it — and because it is the first thing checked below.
-    /// @param _nonce  Governance-chosen sequence number, strictly greater than [`localNonce`].
-    ///                Gaps are fine — only the ordering matters — so this may be sourced from a
-    ///                dedicated counter or from `L1CrossDomainMessenger.messageNonce()`.
+    /// @notice Rotates the L1 address permitted to govern this allowlist. Governance rotates itself,
+    ///         so this can strand the contract, and it fails silently from L1. Rotating to an EOA is
+    ///         terminal; only `PreconfWhitelistGov` can screen for code, since L2 cannot see L1.
+    /// @param _authorizedL1 New L1 governance address, unaliased. Must be a contract on L1.
+    function setAuthorizedL1(address _authorizedL1) external onlyL1Gov {
+        require(_authorizedL1 != address(0), "PreconfWhitelist: authorized L1 sender is the zero address");
+        emit AuthorizedL1Updated(authorizedL1, _authorizedL1);
+        authorizedL1 = _authorizedL1;
+    }
+
+    /// @notice Applies a batch. `from == 0` is a recipient wildcard, `to == 0` a sender wildcard,
+    ///         both zero reverts; adds run before removes and every operation is idempotent. No
+    ///         replay guard needed (a deposit lands once), but a starved `_gasLimit` fails on L2.
     /// @param _add    Rules to authorize.
     /// @param _remove Rules to revoke.
-    function updatePreconfs(uint256 _nonce, Rule[] calldata _add, Rule[] calldata _remove) external onlyL1Gov {
-        require(_nonce > localNonce, "PreconfWhitelist: stale nonce");
+    function updatePreconfs(Rule[] calldata _add, Rule[] calldata _remove) external onlyL1Gov {
         require(_add.length + _remove.length <= MAX_BATCH, "PreconfWhitelist: batch too large");
-        localNonce = _nonce;
         for (uint256 i = 0; i < _add.length; i++) {
             _apply(_add[i].from, _add[i].to, true);
         }
@@ -327,152 +126,122 @@ contract PreconfWhitelist {
         emit WhitelistUpdated(exactPairs.length, fromWildcards.length, toWildcards.length);
     }
 
-    // ===== views =====
-    //
-    // Each set is readable two ways: a paginated getter and an unbounded `getAll*` one. The whole
-    // allowlist is readable the same two ways, through `getRules` / `getAllRules`.
-    //
-    // The unbounded form is the convenient one and is what most tooling should reach for, but it
-    // has a cliff: the returned array is built in memory and every element costs a cold SLOAD, so
-    // past some length the call runs out of gas. For an `eth_call` that ceiling is the RPC node's
-    // `--rpc.gascap` (50M by default), which puts the boundary on the order of 10^4 exact pairs —
-    // far beyond any expected allowlist, but a real limit that moves when governance grows the
-    // list rather than when the caller chooses. For a *contract* caller the block gas limit binds
-    // much sooner. The failure mode is a reverting call, not a truncated result.
-    //
-    // That is what the paginated form is for: it turns the cliff into an explicit parameter, so a
-    // caller that outgrows `getAll*` has somewhere to go without an interface change. The `getAll`
-    // prefix is deliberate — it puts the unboundedness at the call site instead of hiding it
-    // behind an overload of the same name.
-    //
-    // op-reth is unaffected either way: it reads storage directly and calls none of these.
+    // ===== views (op-reth calls none of these; it reads storage directly) =====
+    // Each set reads paginated or unbounded via `getAll*`. The unbounded form costs one cold SLOAD
+    // per element, so past ~10^4 entries it exceeds an eth_call's gas cap and reverts, not truncates.
 
     /// @notice Number of exact rules.
-    /// @return Length of `exactPairs`, i.e. the upper bound for `getExactPairs`'s `_offset`.
+    /// @return Length of `exactPairs`, the exclusive upper bound for `getExactPairs`'s `_offset`.
     function exactPairsLength() external view returns (uint256) {
         return exactPairs.length;
     }
 
     /// @notice Number of sender wildcards.
-    /// @return Length of `fromWildcards`, i.e. the upper bound for `getFromWildcards`'s `_offset`.
+    /// @return Length of `fromWildcards`, the exclusive bound for `getFromWildcards`'s `_offset`.
     function fromWildcardsLength() external view returns (uint256) {
         return fromWildcards.length;
     }
 
     /// @notice Number of recipient wildcards.
-    /// @return Length of `toWildcards`, i.e. the upper bound for `getToWildcards`'s `_offset`.
+    /// @return Length of `toWildcards`, the exclusive bound for `getToWildcards`'s `_offset`.
     function toWildcardsLength() external view returns (uint256) {
         return toWildcards.length;
     }
 
-    /// @notice Number of rules in total, across all three sets.
-    /// @dev    The length `getAllRules` returns, i.e. the upper bound for `getRules`'s `_offset`.
-    ///         Also the size to check before reaching for `getAllRules`: that is the largest of the
-    ///         unbounded getters and so the first to reach the gas cliff described above.
+    /// @notice Total rules across all three sets — the length `getAllRules` returns, the bound for
+    ///         `getRules`, and the size to check before reaching for the unbounded getters.
     /// @return Sum of the three set lengths.
     function rulesLength() external view returns (uint256) {
         return exactPairs.length + fromWildcards.length + toWildcards.length;
     }
 
-    /// @notice Returns up to `_limit` exact rules starting at `_offset`.
-    /// @dev    An out-of-range `_offset` returns an empty array and an over-long `_limit` is
-    ///         truncated, so a caller paging to the end never has to special-case the last page.
-    /// @param _offset Index of the first rule to return. Order is not stable across updates —
-    ///                `_rmExactPair` swaps the last element into the freed position.
-    /// @param _limit  Maximum number of rules to return.
+    /// @notice Up to `_limit` exact rules starting at `_offset`.
+    /// @param _offset Index of the first rule; at or past the end yields an empty array. Order is
+    ///                not stable across updates — removal swaps the last element into the gap.
+    /// @param _limit  Maximum number to return, truncated to what remains after `_offset`.
     /// @return The requested page, shorter than `_limit` when fewer rules remain.
     function getExactPairs(uint256 _offset, uint256 _limit) external view returns (Rule[] memory) {
         return _pageExact(_offset, _limit);
     }
 
-    /// @notice Returns up to `_limit` sender wildcards starting at `_offset`.
-    /// @param _offset Index of the first wildcard to return; at or past the end yields an empty
-    ///                array. Order is not stable across updates — `_rmWildcard` swaps the last element
-    ///                into the freed position.
+    /// @notice Up to `_limit` sender wildcards starting at `_offset`.
+    /// @param _offset Index of the first wildcard; at or past the end yields an empty array. Order
+    ///                is not stable across updates.
     /// @param _limit  Maximum number to return, truncated to what remains after `_offset`.
     /// @return The requested page.
     function getFromWildcards(uint256 _offset, uint256 _limit) external view returns (address[] memory) {
         return _pageWildcards(fromWildcards, _offset, _limit);
     }
 
-    /// @notice Returns up to `_limit` recipient wildcards starting at `_offset`.
-    /// @param _offset Index of the first wildcard to return; at or past the end yields an empty
-    ///                array. Order is not stable across updates — `_rmWildcard` swaps the last element
-    ///                into the freed position.
+    /// @notice Up to `_limit` recipient wildcards starting at `_offset`.
+    /// @param _offset Index of the first wildcard; at or past the end yields an empty array. Order
+    ///                is not stable across updates.
     /// @param _limit  Maximum number to return, truncated to what remains after `_offset`.
     /// @return The requested page.
     function getToWildcards(uint256 _offset, uint256 _limit) external view returns (address[] memory) {
         return _pageWildcards(toWildcards, _offset, _limit);
     }
 
-    /// @notice Returns up to `_limit` rules starting at `_offset`, paging over the **whole**
-    ///         allowlist without distinguishing exact pairs from wildcards — the paginated
-    ///         counterpart of `getAllRules`, with the same concatenation order and the same
-    ///         zero-address encoding for wildcards.
-    /// @param _offset Index of the first rule to return, over the concatenated view.
-    /// @param _limit  Maximum number of rules to return, truncated to what remains.
+    /// @notice Up to `_limit` rules from `_offset` over the whole allowlist — the paginated
+    ///         counterpart of `getAllRules`, same concatenation order and wildcard encoding.
+    /// @param _offset Index into the concatenated view; at or past the total yields an empty array.
+    /// @param _limit  Maximum number to return, truncated to what remains after `_offset`.
     /// @return The requested page, in wire form.
     function getRules(uint256 _offset, uint256 _limit) external view returns (Rule[] memory) {
         return _pageRules(_offset, _limit);
     }
 
-    /// @notice Every exact rule, in one call. Unbounded — see the cliff described above the
-    ///         paginated getters, and fall back to `getExactPairs` if the list ever outgrows this.
+    /// @notice Every exact rule in one call. Unbounded — see the gas cliff noted above.
     /// @return All of `exactPairs`, in storage order.
     function getAllExactPairs() external view returns (Rule[] memory) {
         return _pageExact(0, type(uint256).max);
     }
 
-    /// @notice Every sender wildcard, in one call. Unbounded — see the note above the paginated
-    ///         getters.
+    /// @notice Every sender wildcard in one call. Unbounded — see the note above.
     /// @return All of `fromWildcards`, in storage order.
     function getAllFromWildcards() external view returns (address[] memory) {
         return _pageWildcards(fromWildcards, 0, type(uint256).max);
     }
 
-    /// @notice Every recipient wildcard, in one call. Unbounded — see the note above the paginated
-    ///         getters.
+    /// @notice Every recipient wildcard in one call. Unbounded — see the note above.
     /// @return All of `toWildcards`, in storage order.
     function getAllToWildcards() external view returns (address[] memory) {
         return _pageWildcards(toWildcards, 0, type(uint256).max);
     }
 
-    /// @notice The entire allowlist as one flat `Rule[]`, without distinguishing exact pairs from
-    ///         wildcards — the three sets concatenated, in the order `exactPairs`, `fromWildcards`,
-    ///         `toWildcards`.
+    /// @notice The whole allowlist as one flat `Rule[]`: the three sets concatenated in the order
+    ///         `exactPairs`, `fromWildcards`, `toWildcards`, wildcards in zero-address wire form.
     /// @return Every rule in the allowlist, wildcards included, in wire form.
     function getAllRules() external view returns (Rule[] memory) {
         return _pageRules(0, type(uint256).max);
     }
 
-    /// @notice The eligibility predicate itself: true if `_from -> _to` is allowed by **any** of the
-    ///         three sets. This is the question the sequencer answers per transaction; the three
-    ///         accessors below expose the individual terms.
+    /// @notice The eligibility predicate: true if any of the three sets allows `_from -> _to`. This
+    ///         is the question the sequencer answers per transaction.
     /// @param _from Sender of the transaction.
-    /// @param _to   Recipient, or `address(0)` for a contract creation.
+    /// @param _to   Recipient, or the zero address for a contract creation, which needs no case.
     /// @return True if the transaction is eligible for the preconf fast path.
     function isWhitelist(address _from, address _to) external view returns (bool) {
         return exactPairIndex[_from][_to] != 0 || fromWildcardIndex[_from] != 0 || toWildcardIndex[_to] != 0;
     }
 
-    /// @notice Returns true if `_from -> _to` is an exact rule. Does NOT consider wildcards — see
-    ///         `isFromWildcard` / `isToWildcard`, and the OR in the contract docs.
+    /// @notice True if `_from -> _to` is an exact rule. Does NOT consider wildcards, so this alone
+    ///         does not answer whether traffic is eligible — see `isWhitelist`.
     /// @param _from Sender half of the rule.
-    /// @param _to   Recipient half of the rule. Neither half is ever the zero address in storage,
-    ///              so a zero argument never matches.
+    /// @param _to   Recipient half. Neither half is ever zero in storage, so zero never matches.
     /// @return True if the exact pair is present.
     function isExactPair(address _from, address _to) external view returns (bool) {
         return exactPairIndex[_from][_to] != 0;
     }
 
-    /// @notice Returns true if every transaction from `_addr` is eligible.
+    /// @notice True if every transaction from `_addr` is eligible.
     /// @param _addr Sender to test. The zero address is never stored, so it never matches.
     /// @return True if `_addr` is a sender wildcard.
     function isFromWildcard(address _addr) external view returns (bool) {
         return fromWildcardIndex[_addr] != 0;
     }
 
-    /// @notice Returns true if every transaction to `_addr` is eligible.
+    /// @notice True if every transaction to `_addr` is eligible.
     /// @param _addr Recipient to test. The zero address is never stored, so it never matches.
     /// @return True if `_addr` is a recipient wildcard.
     function isToWildcard(address _addr) external view returns (bool) {
@@ -481,11 +250,9 @@ contract PreconfWhitelist {
 
     // ===== internals =====
 
-    /// @notice Routes one rule to its set and adds or removes it. The single place the three
-    ///         `Rule` forms are interpreted, so the constructor and `updatePreconfs` cannot
-    ///         disagree about them.
-    /// @dev    Takes the halves as value-type arguments rather than a `Rule`, so the same body
-    ///         serves the constructor's `memory` array and `updatePreconfs`'s `calldata` one.
+    /// @notice Routes one rule to its set and adds or removes it — the single place the three forms
+    ///         are interpreted, so the constructor and `updatePreconfs` cannot disagree. Takes
+    ///         halves rather than a `Rule` so one body serves `memory` and `calldata` callers.
     /// @param _from  Sender half, or the zero address to route this rule to `toWildcards`.
     /// @param _to    Recipient half, or the zero address to route it to `fromWildcards`.
     /// @param _isAdd True to authorize the rule, false to revoke it.
@@ -503,10 +270,8 @@ contract PreconfWhitelist {
         }
     }
 
-    /// @notice Appends `(_from, _to)` to `exactPairs` and records its position. No-op if already
-    ///         present. Both halves are known non-zero — `_apply` routed us here precisely
-    ///         because of that.
-    /// @param _from Sender half, known non-zero.
+    /// @notice Appends `(_from, _to)` and records its position. No-op if already present.
+    /// @param _from Sender half, known non-zero — that is why `_apply` routed here.
     /// @param _to   Recipient half, known non-zero.
     function _addExactPair(address _from, address _to) internal {
         if (exactPairIndex[_from][_to] != 0) return;
@@ -514,12 +279,9 @@ contract PreconfWhitelist {
         exactPairIndex[_from][_to] = exactPairs.length;
     }
 
-    /// @notice Removes `(_from, _to)` from `exactPairs` by swapping in the final element and
-    ///         popping, keeping `exactPairIndex` in step. No-op if absent. Order is not preserved;
-    ///         the sequencer treats this as a set.
-    /// @dev    Removing the last element is the degenerate case of the same code: the swap writes
-    ///         the element over itself, the index write restores it, and the `delete` below then
-    ///         clears it for good.
+    /// @notice Removes `(_from, _to)` by swap-and-pop, keeping the index in step. No-op if absent.
+    ///         Removing the last element is the degenerate case of the same code: the swap writes it
+    ///         over itself, the index write restores it, and the `delete` then clears it for good.
     /// @param _from Sender half of the rule to revoke.
     /// @param _to   Recipient half of the rule to revoke.
     function _rmExactPair(address _from, address _to) internal {
@@ -533,12 +295,9 @@ contract PreconfWhitelist {
         delete exactPairIndex[_from][_to];
     }
 
-    /// @notice Appends `_addr` to `_list` and records its position in `_idxMap`. No-op if already
-    ///         present. `_addr` is known non-zero: `_apply` only routes here when the *other* half
-    ///         was the zero marker, and it rejects the all-zero form outright. Nothing may write a
-    ///         zero entry — an unset array element reads back as the zero address on the sequencer
-    ///         side, so a stored zero would be indistinguishable from a slot that was never
-    ///         written.
+    /// @notice Appends `_addr` to `_list` and records its position. No-op if already present.
+    ///         Nothing may store a zero: op-reth reads an unwritten slot back as the zero address,
+    ///         so a stored one would be indistinguishable from absence.
     /// @param _list   Wildcard array to append to — `fromWildcards` or `toWildcards`.
     /// @param _idxMap That array's membership index, written in the same call to stay in step.
     /// @param _addr   Address to authorize, known non-zero.
@@ -554,18 +313,11 @@ contract PreconfWhitelist {
         _idxMap[_addr] = _list.length;
     }
 
-    /// @notice Removes `_addr` from `_list` by swapping in the final element and popping, keeping
-    ///         `_idxMap` in step. No-op if `_addr` is absent.
+    /// @notice Removes `_addr` from `_list` by swap-and-pop, keeping `_idxMap` in step. No-op if absent.
     /// @param _list   Wildcard array to remove from — `fromWildcards` or `toWildcards`.
     /// @param _idxMap That array's membership index, rewritten for the swapped-in element.
     /// @param _addr   Address to revoke.
-    function _rmWildcard(
-        address[] storage _list,
-        mapping(address => uint256) storage _idxMap,
-        address _addr
-    )
-        internal
-    {
+    function _rmWildcard(address[] storage _list, mapping(address => uint256) storage _idxMap, address _addr) internal {
         uint256 idx = _idxMap[_addr];
         if (idx == 0) return;
         uint256 i = idx - 1;
@@ -577,7 +329,7 @@ contract PreconfWhitelist {
     }
 
     /// @notice Shared paging body for `getExactPairs` and `getAllExactPairs`.
-    /// @param _offset Index of the first rule to return; at or past the end yields an empty array.
+    /// @param _offset Index of the first rule; at or past the end yields an empty array.
     /// @param _limit  Maximum number to return, truncated to what remains after `_offset`.
     /// @return out_ The requested page.
     function _pageExact(uint256 _offset, uint256 _limit) internal view returns (Rule[] memory out_) {
@@ -593,8 +345,7 @@ contract PreconfWhitelist {
 
     /// @notice Shared paging body for the two wildcard getters and their `getAll*` counterparts.
     /// @param _list   Wildcard array to page over.
-    /// @param _offset Index of the first element to return; at or past the end yields an empty
-    ///                array.
+    /// @param _offset Index of the first element; at or past the end yields an empty array.
     /// @param _limit  Maximum number to return, truncated to what remains after `_offset`.
     /// @return out_ The requested page.
     function _pageWildcards(
@@ -617,8 +368,8 @@ contract PreconfWhitelist {
     }
 
     /// @notice Shared paging body for `getRules` and `getAllRules`. Maps a position in the virtual
-    ///         concatenation of the three sets onto the array that actually holds it, re-encoding
-    ///         wildcards into the zero-address wire form on the way out.
+    ///         concatenation of the three sets onto the array holding it, re-encoding wildcards into
+    ///         the zero-address wire form on the way out.
     /// @param _offset Index into the concatenated view; at or past the total yields an empty array.
     /// @param _limit  Maximum number to return, truncated to what remains after `_offset`.
     /// @return out_ The requested page.

--- a/packages/contracts-bedrock/src/L2/PreconfWhitelist.sol
+++ b/packages/contracts-bedrock/src/L2/PreconfWhitelist.sol
@@ -69,8 +69,13 @@ contract PreconfWhitelist {
     /// @dev    Held as an `address` because a cast to a contract type is not a compile-time
     ///         constant; the cast happens at the call site (same as `CrossDomainOwnable2`).
     ///         Spelled as a literal rather than `Predeploys.L2_CROSS_DOMAIN_MESSENGER` because
-    ///         solc 0.8.15 rejects a library constant in a constant initializer; the value is
-    ///         asserted equal to that constant in `test/PreconfWhitelist.t.sol`.
+    ///         solc 0.8.15 rejects a library constant in a constant initializer. There is no
+    ///         explicit `assertEq` pinning the two: `MESSENGER` is `internal` and unreachable from
+    ///         a test, so such an assertion would compare two constants and say nothing about this
+    ///         contract. Equality is proven implicitly instead — `test/PreconfWhitelist.t.sol`
+    ///         declares its messenger *as* that predeploy, and the first gate below admits only
+    ///         `msg.sender == MESSENGER`, so every passing governance call in that file depends on
+    ///         it. See the note on `test_updatePreconfs_notMessenger_reverts`.
     address internal constant MESSENGER = 0x4200000000000000000000000000000000000007;
 
     /// @notice The one L1 address permitted to govern this allowlist (the governance Safe), stored
@@ -133,22 +138,42 @@ contract PreconfWhitelist {
     /// @notice Maximum number of rules a single `updatePreconfs` call may touch, summed across
     ///         both arguments.
     /// @dev    Adding an exact pair is the most expensive per-rule operation (two array slots plus
-    ///         one mapping slot, against two slots for a wildcard), so bounding the *total* count
-    ///         by the exact-pair-add capacity makes `MAX_BATCH * gas(_addExactPair)` a strict bound
-    ///         on the call's gas regardless of how the batch is composed. That keeps the relayed
-    ///         call inside the `minGasLimit` governance supplies and well inside the L2 block gas
-    ///         limit. Oversized batches revert before any SSTORE, so they are cheap and change
-    ///         nothing.
+    ///         one mapping slot, against one array slot plus one mapping slot for a wildcard), so
+    ///         bounding the *total* count by the exact-pair-add capacity makes
+    ///         `MAX_BATCH * gas(_addExactPair)` a strict bound on the call's gas regardless of how
+    ///         the batch is composed. Oversized batches revert before any SSTORE, so they are cheap
+    ///         and change nothing.
     ///
     ///         **Measured**, by `test_gas_maxBatchOfPairAdds` / `..OfWildcardAdds`:
     ///
-    ///           pair add      68,018 gas   ->  330 of them = 22,446,092
-    ///           wildcard add  45,680 gas   ->  330 of them = 15,074,717
+    ///           pair add      69,098 gas   ->  256 of them = 17,689,309
+    ///           wildcard add  46,647 gas   ->  256 of them = 11,941,833
     ///
-    ///         330 is calibrated against the same ~23M ceiling the previous cross-product version
-    ///         used (its 500 address-adds at 45,680 each came to 22.84M). Raising this constant
-    ///         means re-running those two tests, not re-deriving from the ratio.
-    uint256 public constant MAX_BATCH = 330;
+    ///         What that has to fit in is **not** the L2 block gas limit — on Mantle that is orders
+    ///         of magnitude larger and never binds. The binding constraint is on **L1**: governance
+    ///         reaches us through `L1CrossDomainMessenger.sendMessage`, which asks
+    ///         `OptimismPortal.depositTransaction` for `baseGas(_message, _minGasLimit)` gas, and
+    ///         that call is `metered`. `ResourceMetering` caps the deposit gas bought per L1 block
+    ///         at `maxResourceLimit` — 20,000,000 in `Constants.DEFAULT_RESOURCE_CONFIG`. So the
+    ///         ceiling on the L2 execution governance can pay for is what survives `baseGas`:
+    ///
+    ///           20,000,000  -  683,088 fixed overhead   (200k constant + 16,516 calldata bytes at
+    ///                                                    16+2 each + 800 + 40k + 90k + 55k)
+    ///                       =  19,316,912, then x 63/64  (the EIP-150 dynamic term)
+    ///                       =  19,015,085 of `_minGasLimit`
+    ///
+    ///         256 pair adds need 17,689,309 of that — **7% headroom**. Extrapolating the two
+    ///         measurements puts the hard ceiling near 276 rules, so 256 is the power of two just
+    ///         below it. The headroom is not decoration: `maxResourceLimit` is a budget
+    ///         *shared across every depositor in the L1 block*, so the 19M figure is the best case
+    ///         of an otherwise-idle block. Buying near it is also expensive, since the target is
+    ///         `maxResourceLimit / elasticityMultiplier` = 2,000,000 and the deposit base fee climbs
+    ///         against that target.
+    ///
+    ///         Raising this constant means re-running those two tests and re-deriving the ceiling
+    ///         above, not scaling from the ratio. Lowering `maxResourceLimit` on L1 lowers the
+    ///         ceiling too, and nothing here would notice — see the warning on `updatePreconfs`.
+    uint256 public constant MAX_BATCH = 256;
 
     /// @notice The layout this contract declares, written to [`layoutVersion`] at construction.
     /// @dev    Bump on **any** change to the storage layout above — a reordering, an insertion, or
@@ -230,6 +255,15 @@ contract PreconfWhitelist {
     ///         No normalization or deduplication happens across the three sets. `(A, B)` and
     ///         `(A, 0)` may both be present; both match, and removing one leaves the other. Which
     ///         of them expresses governance's intent is not something this contract can infer.
+    /// @dev    [`MAX_BATCH`] bounds this call's gas, but the matching *supply* of gas is an L1-side
+    ///         decision this contract cannot see or check: governance picks `_minGasLimit` when it
+    ///         calls `sendMessage`, and the portal's `maxResourceLimit` caps what that may be. If
+    ///         either is too small, the relayed call runs out of gas inside
+    ///         `L2CrossDomainMessenger.relayMessage`, which records the message as failed rather
+    ///         than reverting the block — so the allowlist silently stays as it was, and the L1
+    ///         transaction that sent it still succeeded. Governance must verify on L2 that the
+    ///         update landed; a batch at or below [`MAX_BATCH`] is a necessary condition, not a
+    ///         sufficient one.
     /// @param _add    Rules to authorize.
     /// @param _remove Rules to revoke.
     function updatePreconfs(Rule[] calldata _add, Rule[] calldata _remove) external onlyL1Gov {

--- a/packages/contracts-bedrock/src/L2/PreconfWhitelist.sol
+++ b/packages/contracts-bedrock/src/L2/PreconfWhitelist.sol
@@ -84,6 +84,12 @@ contract PreconfWhitelist {
     /// @dev    Immutable, so it occupies no storage slot and cannot shift the layout below.
     ///         Rotating the governance Safe therefore requires redeploying this contract and
     ///         repointing op-reth at the new address.
+    ///
+    ///         The codebase-wide ban on immutables exists for proxied contracts, where an immutable
+    ///         set at implementation-deploy time diverges from the proxy. This contract is neither
+    ///         proxied nor a predeploy (see the note above), and occupying no slot is exactly what
+    ///         keeps the load-bearing layout below out of reach of a governance-address change.
+    // nosemgrep: sol-safety-no-immutable-variables
     address public immutable AUTHORIZED_L1;
 
     /// @notice Exact `(from, to)` rules — the rules with **both halves non-zero**, as distinct from
@@ -308,14 +314,7 @@ contract PreconfWhitelist {
     ///                dedicated counter or from `L1CrossDomainMessenger.messageNonce()`.
     /// @param _add    Rules to authorize.
     /// @param _remove Rules to revoke.
-    function updatePreconfs(
-        uint256 _nonce,
-        Rule[] calldata _add,
-        Rule[] calldata _remove
-    )
-        external
-        onlyL1Gov
-    {
+    function updatePreconfs(uint256 _nonce, Rule[] calldata _add, Rule[] calldata _remove) external onlyL1Gov {
         require(_nonce > localNonce, "PreconfWhitelist: stale nonce");
         require(_add.length + _remove.length <= MAX_BATCH, "PreconfWhitelist: batch too large");
         localNonce = _nonce;
@@ -543,7 +542,13 @@ contract PreconfWhitelist {
     /// @param _list   Wildcard array to append to — `fromWildcards` or `toWildcards`.
     /// @param _idxMap That array's membership index, written in the same call to stay in step.
     /// @param _addr   Address to authorize, known non-zero.
-    function _addWildcard(address[] storage _list, mapping(address => uint256) storage _idxMap, address _addr) internal {
+    function _addWildcard(
+        address[] storage _list,
+        mapping(address => uint256) storage _idxMap,
+        address _addr
+    )
+        internal
+    {
         if (_idxMap[_addr] != 0) return;
         _list.push(_addr);
         _idxMap[_addr] = _list.length;

--- a/packages/contracts-bedrock/src/L2/PreconfWhitelist.sol
+++ b/packages/contracts-bedrock/src/L2/PreconfWhitelist.sol
@@ -10,12 +10,12 @@ import { L2CrossDomainMessenger } from "./L2CrossDomainMessenger.sol";
 ///
 ///         Eligibility is an **explicit `(from, to)` relation**, not a cross product:
 ///
-///           eligible(from, to)  <=>  isWhitelistPair(from, to)
+///           eligible(from, to)  <=>  isExactPair(from, to)
 ///                                ||  isFromWildcard(from)
 ///                                ||  isToWildcard(to)
 ///
 ///         The predicate is a plain OR with no precedence and no deny list. In particular,
-///         removing `(A, X)` from the pair set does NOT stop `A -> X` if `A` is still a from
+///         removing `(A, X)` from the exact set does NOT stop `A -> X` if `A` is still a from
 ///         wildcard; the wildcard has to be removed too.
 ///
 ///         Updates may only originate from a single authorized L1 address (the governance Safe),
@@ -27,7 +27,14 @@ import { L2CrossDomainMessenger } from "./L2CrossDomainMessenger.sol";
 ///         This is a regular deployed contract, NOT a predeploy — it is deployed with a normal L2
 ///         transaction and its address is passed to op-reth via `--preconf.whitelist-address`.
 ///
-/// @dev    STORAGE LAYOUT IS LOAD-BEARING. op-reth reads `pairs` (slot 0), `fromWildcards`
+/// @dev    A note on vocabulary, because one word used to carry two meanings. A [`Rule`] is the
+///         **wire format**: the struct governance submits, in any of the three forms below. An
+///         **exact pair** is one of the three *sets* — the rules whose halves are both non-zero,
+///         held in [`exactPairs`]. Every exact pair is a rule; a wildcard is a rule too, but not
+///         an exact pair. Identifiers follow that split: `Rule` and `getAllRules` speak about the
+///         wire format, everything spelled `exactPair*` speaks about the one set.
+///
+///         STORAGE LAYOUT IS LOAD-BEARING. op-reth reads `exactPairs` (slot 0), `fromWildcards`
 ///         (slot 2) and `toWildcards` (slot 4) directly out of state — it never calls the view
 ///         functions below, because the classifier's eligibility check is a synchronous,
 ///         no-IO hot path that reads an in-memory mirror. The six state variables must therefore
@@ -38,15 +45,21 @@ import { L2CrossDomainMessenger } from "./L2CrossDomainMessenger.sol";
 ///         `test/PreconfWhitelist.t.sol` asserts the layout so a drift breaks CI here first.
 ///         `layoutVersion` (slot 6) is the runtime guard for the same coupling — see its docs.
 ///
-///         Note especially that a `Pair` element spans **two** slots: two addresses are 40 bytes,
-///         so they cannot share one. `pairs[i].from` lives at `keccak256(0) + 2i` and
-///         `pairs[i].to` at `keccak256(0) + 2i + 1`. The Rust reader depends on that stride.
+///         Note especially that a `Rule` element spans **two** slots: two addresses are 40 bytes,
+///         so they cannot share one. `exactPairs[i].from` lives at `keccak256(0) + 2i` and
+///         `exactPairs[i].to` at `keccak256(0) + 2i + 1`. The Rust reader depends on that stride.
+///
+///         Renaming anything below is safe for op-reth as long as the *declaration order* holds:
+///         the Rust side binds no view function and reads slots by number, and the sole ABI
+///         couplings are the `updatePreconfs` selector and the `WhitelistUpdated` topic0, neither
+///         of which depends on a parameter or variable name. A rename must NOT bump
+///         [`LAYOUT_VERSION`] — nothing moved.
 contract PreconfWhitelist {
-    /// @notice One allowlist rule. Both halves non-zero means an exact match; exactly one zero
-    ///         half means a wildcard on the other side (see `updatePreconfs`). Stored entries in
-    ///         `pairs` always have both halves non-zero — the zero address is a calldata-only
-    ///         marker and never reaches storage.
-    struct Pair {
+    /// @notice One allowlist rule, in the form governance submits it. Both halves non-zero means an
+    ///         exact match; exactly one zero half means a wildcard on the other side (see
+    ///         `updatePreconfs`). Stored entries in `exactPairs` always have both halves non-zero —
+    ///         the zero address is a calldata-only marker and never reaches storage.
+    struct Rule {
         address from;
         address to;
     }
@@ -68,18 +81,20 @@ contract PreconfWhitelist {
     ///         repointing op-reth at the new address.
     address public immutable AUTHORIZED_L1;
 
-    /// @notice Exact `(from, to)` rules. Slot 0 — see the storage-layout note above. Elements span
-    ///         two slots each.
-    Pair[] public pairs;
+    /// @notice Exact `(from, to)` rules — the rules with **both halves non-zero**, as distinct from
+    ///         the two wildcard sets below. Slot 0 — see the storage-layout note above. Elements
+    ///         span two slots each.
+    Rule[] public exactPairs;
 
-    /// @notice Membership index for `pairs`. Slot 1. Stores `index + 1`, so 0 means "not present".
+    /// @notice Membership index for `exactPairs`. Slot 1. Stores `index + 1`, so 0 means "not
+    ///         present".
     /// @dev    Nested rather than a single `bytes32` key over `keccak256(abi.encode(from, to))`:
     ///         the nested form is measurably cheaper (Solidity computes mapping slots in scratch
     ///         space, while `abi.encode` pays for memory allocation — ~355 gas per SSTORE,
     ///         ~379 per SLOAD), and its generated getter takes the two addresses directly instead
     ///         of forcing every off-chain caller to reproduce a hashing scheme. It cannot be a
-    ///         `bool`: `_rmPair` needs the element's array position.
-    mapping(address => mapping(address => uint256)) public pairIndex;
+    ///         `bool`: `_rmExactPair` needs the element's array position.
+    mapping(address => mapping(address => uint256)) public exactPairIndex;
 
     /// @notice Senders whose transactions are all eligible, whatever the recipient. Slot 2 — see
     ///         the storage-layout note above.
@@ -104,7 +119,7 @@ contract PreconfWhitelist {
     ///         this layout. Without a marker, a version skew in either direction is silent and
     ///         actively wrong rather than merely stale:
     ///
-    ///         * a binary built for the previous cross-product layout reads `pairs` with a
+    ///         * a binary built for the previous cross-product layout reads `exactPairs` with a
     ///           one-slot stride, so it takes alternating `from`/`to` halves for a sender list;
     ///         * a binary built for this layout, pointed at the previous contract, reads that
     ///           contract's *recipient* list out of slot 2 and installs it as **sender
@@ -119,10 +134,11 @@ contract PreconfWhitelist {
     ///         both arguments.
     /// @dev    Adding an exact pair is the most expensive per-rule operation (two array slots plus
     ///         one mapping slot, against two slots for a wildcard), so bounding the *total* count
-    ///         by the pair-add capacity makes `MAX_BATCH * gas(addPair)` a strict upper bound on
-    ///         the call's gas regardless of how the batch is composed. That keeps the relayed call
-    ///         inside the `minGasLimit` governance supplies and well inside the L2 block gas limit.
-    ///         Oversized batches revert before any SSTORE, so they are cheap and change nothing.
+    ///         by the exact-pair-add capacity makes `MAX_BATCH * gas(_addExactPair)` a strict bound
+    ///         on the call's gas regardless of how the batch is composed. That keeps the relayed
+    ///         call inside the `minGasLimit` governance supplies and well inside the L2 block gas
+    ///         limit. Oversized batches revert before any SSTORE, so they are cheap and change
+    ///         nothing.
     ///
     ///         **Measured**, by `test_gas_maxBatchOfPairAdds` / `..OfWildcardAdds`:
     ///
@@ -136,7 +152,8 @@ contract PreconfWhitelist {
 
     /// @notice The layout this contract declares, written to [`layoutVersion`] at construction.
     /// @dev    Bump on **any** change to the storage layout above — a reordering, an insertion, or
-    ///         a change to `Pair`'s field count. op-reth pins the same number in
+    ///         a change to `Rule`'s field count. Renaming a variable is not such a change; the
+    ///         layout is positional. op-reth pins the same number in
     ///         `mantle-reth/crates/preconf/src/whitelist.rs` (`EXPECTED_LAYOUT_VERSION`) and
     ///         refuses to start against anything else, so the two move together or the node says
     ///         so at boot instead of mis-reading state for the rest of its life.
@@ -152,25 +169,28 @@ contract PreconfWhitelist {
     ///         refreshing — it would keep running on whatever it read at bootstrap, with no error.
     ///         The Rust constant is `WHITELIST_UPDATED_TOPIC0` in
     ///         `mantle-reth/crates/preconf/src/whitelist.rs`; both sides assert the same literal.
-    /// @param pairCount         Number of exact rules after the update.
+    ///         Parameter *names* are not part of the signature, so renaming them is free.
+    /// @param exactPairCount    Number of exact rules after the update.
     /// @param fromWildcardCount Number of sender wildcards after the update.
     /// @param toWildcardCount   Number of recipient wildcards after the update.
-    event WhitelistUpdated(uint256 pairCount, uint256 fromWildcardCount, uint256 toWildcardCount);
+    event WhitelistUpdated(uint256 exactPairCount, uint256 fromWildcardCount, uint256 toWildcardCount);
 
     /// @notice Seeds the initial allowlist so the contract is usable the moment it is deployed,
     ///         with no follow-up governance message required.
     /// @dev    Deliberately not subject to `MAX_BATCH`: deployment gas is bounded by whoever sends
     ///         the deployment transaction, not by a relayed message's `minGasLimit`.
     /// @param _authorizedL1 L1 governance address permitted to update the allowlist.
-    /// @param _initPairs    Initial rules, in the same three forms `updatePreconfs` accepts.
-    constructor(address _authorizedL1, Pair[] memory _initPairs) {
+    /// @param _initRules    Initial rules, in the same three forms `updatePreconfs` accepts. A
+    ///                      `getAllRules()` reading from an existing deployment can be passed here
+    ///                      verbatim to clone its allowlist.
+    constructor(address _authorizedL1, Rule[] memory _initRules) {
         require(_authorizedL1 != address(0), "PreconfWhitelist: authorized L1 sender is the zero address");
         AUTHORIZED_L1 = _authorizedL1;
         layoutVersion = LAYOUT_VERSION;
-        for (uint256 i = 0; i < _initPairs.length; i++) {
-            _apply(_initPairs[i].from, _initPairs[i].to, true);
+        for (uint256 i = 0; i < _initRules.length; i++) {
+            _apply(_initRules[i].from, _initRules[i].to, true);
         }
-        emit WhitelistUpdated(pairs.length, fromWildcards.length, toWildcards.length);
+        emit WhitelistUpdated(exactPairs.length, fromWildcards.length, toWildcards.length);
     }
 
     /// @notice Restricts a function to cross-domain messages sent by `AUTHORIZED_L1`.
@@ -189,9 +209,9 @@ contract PreconfWhitelist {
         _;
     }
 
-    /// @notice Applies a batch of allowlist changes. Each `Pair` is routed by its zero halves:
+    /// @notice Applies a batch of allowlist changes. Each `Rule` is routed by its zero halves:
     ///
-    ///           (from != 0, to != 0)  ->  exact rule, `pairs`
+    ///           (from != 0, to != 0)  ->  exact rule, `exactPairs`
     ///           (from == 0, to != 0)  ->  recipient wildcard, `toWildcards`
     ///           (from != 0, to == 0)  ->  sender wildcard, `fromWildcards`
     ///           (from == 0, to == 0)  ->  reverts
@@ -212,7 +232,7 @@ contract PreconfWhitelist {
     ///         of them expresses governance's intent is not something this contract can infer.
     /// @param _add    Rules to authorize.
     /// @param _remove Rules to revoke.
-    function updatePreconfs(Pair[] calldata _add, Pair[] calldata _remove) external onlyL1Gov {
+    function updatePreconfs(Rule[] calldata _add, Rule[] calldata _remove) external onlyL1Gov {
         require(_add.length + _remove.length <= MAX_BATCH, "PreconfWhitelist: batch too large");
         for (uint256 i = 0; i < _add.length; i++) {
             _apply(_add[i].from, _add[i].to, true);
@@ -220,21 +240,33 @@ contract PreconfWhitelist {
         for (uint256 i = 0; i < _remove.length; i++) {
             _apply(_remove[i].from, _remove[i].to, false);
         }
-        emit WhitelistUpdated(pairs.length, fromWildcards.length, toWildcards.length);
+        emit WhitelistUpdated(exactPairs.length, fromWildcards.length, toWildcards.length);
     }
 
     // ===== views =====
     //
-    // Only paginated getters are provided. A full-list getter works right up until the list grows
-    // past the point where it does not, and its failure mode is a reverting call rather than a
-    // truncated result — a hard break for off-chain tooling, arriving at a moment governance
-    // chooses rather than one the caller controls. Paging makes that boundary an explicit
-    // parameter. op-reth is unaffected either way: it reads storage directly.
+    // Each set is readable two ways: a paginated getter and an unbounded `getAll*` one. The whole
+    // allowlist is readable the same two ways, through `getRules` / `getAllRules`.
+    //
+    // The unbounded form is the convenient one and is what most tooling should reach for, but it
+    // has a cliff: the returned array is built in memory and every element costs a cold SLOAD, so
+    // past some length the call runs out of gas. For an `eth_call` that ceiling is the RPC node's
+    // `--rpc.gascap` (50M by default), which puts the boundary on the order of 10^4 exact pairs —
+    // far beyond any expected allowlist, but a real limit that moves when governance grows the
+    // list rather than when the caller chooses. For a *contract* caller the block gas limit binds
+    // much sooner. The failure mode is a reverting call, not a truncated result.
+    //
+    // That is what the paginated form is for: it turns the cliff into an explicit parameter, so a
+    // caller that outgrows `getAll*` has somewhere to go without an interface change. The `getAll`
+    // prefix is deliberate — it puts the unboundedness at the call site instead of hiding it
+    // behind an overload of the same name.
+    //
+    // op-reth is unaffected either way: it reads storage directly and calls none of these.
 
     /// @notice Number of exact rules.
-    /// @return Length of `pairs`, i.e. the upper bound for `getPairs`'s `_offset`.
-    function pairsLength() external view returns (uint256) {
-        return pairs.length;
+    /// @return Length of `exactPairs`, i.e. the upper bound for `getExactPairs`'s `_offset`.
+    function exactPairsLength() external view returns (uint256) {
+        return exactPairs.length;
     }
 
     /// @notice Number of sender wildcards.
@@ -249,63 +281,94 @@ contract PreconfWhitelist {
         return toWildcards.length;
     }
 
+    /// @notice Number of rules in total, across all three sets.
+    /// @dev    The length `getAllRules` returns, i.e. the upper bound for `getRules`'s `_offset`.
+    ///         Also the size to check before reaching for `getAllRules`: that is the largest of the
+    ///         unbounded getters and so the first to reach the gas cliff described above.
+    /// @return Sum of the three set lengths.
+    function rulesLength() external view returns (uint256) {
+        return exactPairs.length + fromWildcards.length + toWildcards.length;
+    }
+
     /// @notice Returns up to `_limit` exact rules starting at `_offset`.
     /// @dev    An out-of-range `_offset` returns an empty array and an over-long `_limit` is
     ///         truncated, so a caller paging to the end never has to special-case the last page.
     /// @param _offset Index of the first rule to return. Order is not stable across updates —
-    ///                `_rmPair` swaps the last element into the freed position.
+    ///                `_rmExactPair` swaps the last element into the freed position.
     /// @param _limit  Maximum number of rules to return.
-    /// @return out_ The requested page, shorter than `_limit` when fewer rules remain.
-    function getPairs(uint256 _offset, uint256 _limit) external view returns (Pair[] memory out_) {
-        uint256 len = pairs.length;
-        if (_offset >= len) return new Pair[](0);
-        uint256 n = len - _offset;
-        if (_limit < n) n = _limit;
-        out_ = new Pair[](n);
-        for (uint256 i = 0; i < n; i++) {
-            out_[i] = pairs[_offset + i];
-        }
+    /// @return The requested page, shorter than `_limit` when fewer rules remain.
+    function getExactPairs(uint256 _offset, uint256 _limit) external view returns (Rule[] memory) {
+        return _pageExact(_offset, _limit);
     }
 
     /// @notice Returns up to `_limit` sender wildcards starting at `_offset`.
     /// @param _offset Index of the first wildcard to return; at or past the end yields an empty
-    ///                array. Order is not stable across updates — `_rmAddr` swaps the last element
+    ///                array. Order is not stable across updates — `_rmWildcard` swaps the last element
     ///                into the freed position.
     /// @param _limit  Maximum number to return, truncated to what remains after `_offset`.
     /// @return The requested page.
     function getFromWildcards(uint256 _offset, uint256 _limit) external view returns (address[] memory) {
-        return _page(fromWildcards, _offset, _limit);
+        return _pageWildcards(fromWildcards, _offset, _limit);
     }
 
     /// @notice Returns up to `_limit` recipient wildcards starting at `_offset`.
     /// @param _offset Index of the first wildcard to return; at or past the end yields an empty
-    ///                array. Order is not stable across updates — `_rmAddr` swaps the last element
+    ///                array. Order is not stable across updates — `_rmWildcard` swaps the last element
     ///                into the freed position.
     /// @param _limit  Maximum number to return, truncated to what remains after `_offset`.
     /// @return The requested page.
     function getToWildcards(uint256 _offset, uint256 _limit) external view returns (address[] memory) {
-        return _page(toWildcards, _offset, _limit);
+        return _pageWildcards(toWildcards, _offset, _limit);
+    }
+
+    /// @notice Returns up to `_limit` rules starting at `_offset`, paging over the **whole**
+    ///         allowlist without distinguishing exact pairs from wildcards — the paginated
+    ///         counterpart of `getAllRules`, with the same concatenation order and the same
+    ///         zero-address encoding for wildcards.
+    /// @param _offset Index of the first rule to return, over the concatenated view.
+    /// @param _limit  Maximum number of rules to return, truncated to what remains.
+    /// @return The requested page, in wire form.
+    function getRules(uint256 _offset, uint256 _limit) external view returns (Rule[] memory) {
+        return _pageRules(_offset, _limit);
+    }
+
+    /// @notice Every exact rule, in one call. Unbounded — see the cliff described above the
+    ///         paginated getters, and fall back to `getExactPairs` if the list ever outgrows this.
+    /// @return All of `exactPairs`, in storage order.
+    function getAllExactPairs() external view returns (Rule[] memory) {
+        return _pageExact(0, type(uint256).max);
+    }
+
+    /// @notice Every sender wildcard, in one call. Unbounded — see the note above the paginated
+    ///         getters.
+    /// @return All of `fromWildcards`, in storage order.
+    function getAllFromWildcards() external view returns (address[] memory) {
+        return _pageWildcards(fromWildcards, 0, type(uint256).max);
+    }
+
+    /// @notice Every recipient wildcard, in one call. Unbounded — see the note above the paginated
+    ///         getters.
+    /// @return All of `toWildcards`, in storage order.
+    function getAllToWildcards() external view returns (address[] memory) {
+        return _pageWildcards(toWildcards, 0, type(uint256).max);
+    }
+
+    /// @notice The entire allowlist as one flat `Rule[]`, without distinguishing exact pairs from
+    ///         wildcards — the three sets concatenated, in the order `exactPairs`, `fromWildcards`,
+    ///         `toWildcards`.
+    /// @return Every rule in the allowlist, wildcards included, in wire form.
+    function getAllRules() external view returns (Rule[] memory) {
+        return _pageRules(0, type(uint256).max);
     }
 
     /// @notice The eligibility predicate itself: true if `_from -> _to` is allowed by **any** of the
     ///         three sets. This is the question the sequencer answers per transaction; the three
     ///         accessors below expose the individual terms.
-    /// @dev    A plain OR, matching the relation in the contract docs. No precedence and no deny
-    ///         list: revoking the exact pair `(A, B)` still leaves `A -> B` eligible while `A` is a
-    ///         sender wildcard.
-    ///
-    ///         Passing `address(0)` for `_to` yields the contract-creation answer without a special
-    ///         case. A creation has no recipient, so only a sender wildcard can authorize it — and
-    ///         since the zero address is a calldata-only marker that never reaches storage, both the
-    ///         pair term and the recipient term are necessarily false, leaving exactly
-    ///         `isFromWildcard(_from)`. The sequencer's own check
-    ///         (`Whitelist::is_eligible` in `mantle-reth/crates/preconf/src/classifier.rs`) reaches
-    ///         the same answer through an explicit `Option<Address>`.
     /// @param _from Sender of the transaction.
     /// @param _to   Recipient, or `address(0)` for a contract creation.
     /// @return True if the transaction is eligible for the preconf fast path.
     function isWhitelist(address _from, address _to) external view returns (bool) {
-        return pairIndex[_from][_to] != 0 || fromWildcardIndex[_from] != 0 || toWildcardIndex[_to] != 0;
+        return exactPairIndex[_from][_to] != 0 || fromWildcardIndex[_from] != 0 || toWildcardIndex[_to] != 0;
     }
 
     /// @notice Returns true if `_from -> _to` is an exact rule. Does NOT consider wildcards — see
@@ -314,8 +377,8 @@ contract PreconfWhitelist {
     /// @param _to   Recipient half of the rule. Neither half is ever the zero address in storage,
     ///              so a zero argument never matches.
     /// @return True if the exact pair is present.
-    function isWhitelistPair(address _from, address _to) external view returns (bool) {
-        return pairIndex[_from][_to] != 0;
+    function isExactPair(address _from, address _to) external view returns (bool) {
+        return exactPairIndex[_from][_to] != 0;
     }
 
     /// @notice Returns true if every transaction from `_addr` is eligible.
@@ -335,9 +398,9 @@ contract PreconfWhitelist {
     // ===== internals =====
 
     /// @notice Routes one rule to its set and adds or removes it. The single place the three
-    ///         `Pair` forms are interpreted, so the constructor and `updatePreconfs` cannot
+    ///         `Rule` forms are interpreted, so the constructor and `updatePreconfs` cannot
     ///         disagree about them.
-    /// @dev    Takes the halves as value-type arguments rather than a `Pair`, so the same body
+    /// @dev    Takes the halves as value-type arguments rather than a `Rule`, so the same body
     ///         serves the constructor's `memory` array and `updatePreconfs`'s `calldata` one.
     /// @param _from  Sender half, or the zero address to route this rule to `toWildcards`.
     /// @param _to    Recipient half, or the zero address to route it to `fromWildcards`.
@@ -345,45 +408,45 @@ contract PreconfWhitelist {
     function _apply(address _from, address _to, bool _isAdd) internal {
         require(_from != address(0) || _to != address(0), "PreconfWhitelist: pair is all-zero");
         if (_from == address(0)) {
-            if (_isAdd) _addAddr(toWildcards, toWildcardIndex, _to);
-            else _rmAddr(toWildcards, toWildcardIndex, _to);
+            if (_isAdd) _addWildcard(toWildcards, toWildcardIndex, _to);
+            else _rmWildcard(toWildcards, toWildcardIndex, _to);
         } else if (_to == address(0)) {
-            if (_isAdd) _addAddr(fromWildcards, fromWildcardIndex, _from);
-            else _rmAddr(fromWildcards, fromWildcardIndex, _from);
+            if (_isAdd) _addWildcard(fromWildcards, fromWildcardIndex, _from);
+            else _rmWildcard(fromWildcards, fromWildcardIndex, _from);
         } else {
-            if (_isAdd) _addPair(_from, _to);
-            else _rmPair(_from, _to);
+            if (_isAdd) _addExactPair(_from, _to);
+            else _rmExactPair(_from, _to);
         }
     }
 
-    /// @notice Appends `(_from, _to)` to `pairs` and records its position. No-op if already
+    /// @notice Appends `(_from, _to)` to `exactPairs` and records its position. No-op if already
     ///         present. Both halves are known non-zero — `_apply` routed us here precisely
     ///         because of that.
     /// @param _from Sender half, known non-zero.
     /// @param _to   Recipient half, known non-zero.
-    function _addPair(address _from, address _to) internal {
-        if (pairIndex[_from][_to] != 0) return;
-        pairs.push(Pair({ from: _from, to: _to }));
-        pairIndex[_from][_to] = pairs.length;
+    function _addExactPair(address _from, address _to) internal {
+        if (exactPairIndex[_from][_to] != 0) return;
+        exactPairs.push(Rule({ from: _from, to: _to }));
+        exactPairIndex[_from][_to] = exactPairs.length;
     }
 
-    /// @notice Removes `(_from, _to)` from `pairs` by swapping in the final element and popping,
-    ///         keeping `pairIndex` in step. No-op if absent. Order is not preserved; the sequencer
-    ///         treats this as a set.
+    /// @notice Removes `(_from, _to)` from `exactPairs` by swapping in the final element and
+    ///         popping, keeping `exactPairIndex` in step. No-op if absent. Order is not preserved;
+    ///         the sequencer treats this as a set.
     /// @dev    Removing the last element is the degenerate case of the same code: the swap writes
     ///         the element over itself, the index write restores it, and the `delete` below then
     ///         clears it for good.
     /// @param _from Sender half of the rule to revoke.
     /// @param _to   Recipient half of the rule to revoke.
-    function _rmPair(address _from, address _to) internal {
-        uint256 idx = pairIndex[_from][_to];
+    function _rmExactPair(address _from, address _to) internal {
+        uint256 idx = exactPairIndex[_from][_to];
         if (idx == 0) return;
         uint256 i = idx - 1;
-        Pair memory last = pairs[pairs.length - 1];
-        pairs[i] = last;
-        pairIndex[last.from][last.to] = i + 1;
-        pairs.pop();
-        delete pairIndex[_from][_to];
+        Rule memory last = exactPairs[exactPairs.length - 1];
+        exactPairs[i] = last;
+        exactPairIndex[last.from][last.to] = i + 1;
+        exactPairs.pop();
+        delete exactPairIndex[_from][_to];
     }
 
     /// @notice Appends `_addr` to `_list` and records its position in `_idxMap`. No-op if already
@@ -395,7 +458,7 @@ contract PreconfWhitelist {
     /// @param _list   Wildcard array to append to — `fromWildcards` or `toWildcards`.
     /// @param _idxMap That array's membership index, written in the same call to stay in step.
     /// @param _addr   Address to authorize, known non-zero.
-    function _addAddr(address[] storage _list, mapping(address => uint256) storage _idxMap, address _addr) internal {
+    function _addWildcard(address[] storage _list, mapping(address => uint256) storage _idxMap, address _addr) internal {
         if (_idxMap[_addr] != 0) return;
         _list.push(_addr);
         _idxMap[_addr] = _list.length;
@@ -406,7 +469,7 @@ contract PreconfWhitelist {
     /// @param _list   Wildcard array to remove from — `fromWildcards` or `toWildcards`.
     /// @param _idxMap That array's membership index, rewritten for the swapped-in element.
     /// @param _addr   Address to revoke.
-    function _rmAddr(address[] storage _list, mapping(address => uint256) storage _idxMap, address _addr) internal {
+    function _rmWildcard(address[] storage _list, mapping(address => uint256) storage _idxMap, address _addr) internal {
         uint256 idx = _idxMap[_addr];
         if (idx == 0) return;
         uint256 i = idx - 1;
@@ -417,13 +480,28 @@ contract PreconfWhitelist {
         delete _idxMap[_addr];
     }
 
-    /// @notice Shared paging body for the two wildcard getters.
+    /// @notice Shared paging body for `getExactPairs` and `getAllExactPairs`.
+    /// @param _offset Index of the first rule to return; at or past the end yields an empty array.
+    /// @param _limit  Maximum number to return, truncated to what remains after `_offset`.
+    /// @return out_ The requested page.
+    function _pageExact(uint256 _offset, uint256 _limit) internal view returns (Rule[] memory out_) {
+        uint256 len = exactPairs.length;
+        if (_offset >= len) return new Rule[](0);
+        uint256 n = len - _offset;
+        if (_limit < n) n = _limit;
+        out_ = new Rule[](n);
+        for (uint256 i = 0; i < n; i++) {
+            out_[i] = exactPairs[_offset + i];
+        }
+    }
+
+    /// @notice Shared paging body for the two wildcard getters and their `getAll*` counterparts.
     /// @param _list   Wildcard array to page over.
     /// @param _offset Index of the first element to return; at or past the end yields an empty
     ///                array.
     /// @param _limit  Maximum number to return, truncated to what remains after `_offset`.
     /// @return out_ The requested page.
-    function _page(
+    function _pageWildcards(
         address[] storage _list,
         uint256 _offset,
         uint256 _limit
@@ -439,6 +517,33 @@ contract PreconfWhitelist {
         out_ = new address[](n);
         for (uint256 i = 0; i < n; i++) {
             out_[i] = _list[_offset + i];
+        }
+    }
+
+    /// @notice Shared paging body for `getRules` and `getAllRules`. Maps a position in the virtual
+    ///         concatenation of the three sets onto the array that actually holds it, re-encoding
+    ///         wildcards into the zero-address wire form on the way out.
+    /// @param _offset Index into the concatenated view; at or past the total yields an empty array.
+    /// @param _limit  Maximum number to return, truncated to what remains after `_offset`.
+    /// @return out_ The requested page.
+    function _pageRules(uint256 _offset, uint256 _limit) internal view returns (Rule[] memory out_) {
+        uint256 eLen = exactPairs.length;
+        uint256 fLen = fromWildcards.length;
+        uint256 tLen = toWildcards.length;
+        uint256 total = eLen + fLen + tLen;
+        if (_offset >= total) return new Rule[](0);
+        uint256 n = total - _offset;
+        if (_limit < n) n = _limit;
+        out_ = new Rule[](n);
+        for (uint256 i = 0; i < n; i++) {
+            uint256 j = _offset + i;
+            if (j < eLen) {
+                out_[i] = exactPairs[j];
+            } else if (j < eLen + fLen) {
+                out_[i] = Rule({ from: fromWildcards[j - eLen], to: address(0) });
+            } else {
+                out_[i] = Rule({ from: address(0), to: toWildcards[j - eLen - fLen] });
+            }
         }
     }
 }

--- a/packages/contracts-bedrock/src/L2/PreconfWhitelist.sol
+++ b/packages/contracts-bedrock/src/L2/PreconfWhitelist.sol
@@ -317,7 +317,13 @@ contract PreconfWhitelist {
     /// @param _list   Wildcard array to remove from — `fromWildcards` or `toWildcards`.
     /// @param _idxMap That array's membership index, rewritten for the swapped-in element.
     /// @param _addr   Address to revoke.
-    function _rmWildcard(address[] storage _list, mapping(address => uint256) storage _idxMap, address _addr) internal {
+    function _rmWildcard(
+        address[] storage _list,
+        mapping(address => uint256) storage _idxMap,
+        address _addr
+    )
+        internal
+    {
         uint256 idx = _idxMap[_addr];
         if (idx == 0) return;
         uint256 i = idx - 1;

--- a/packages/contracts-bedrock/src/L2/PreconfWhitelist.sol
+++ b/packages/contracts-bedrock/src/L2/PreconfWhitelist.sol
@@ -559,7 +559,13 @@ contract PreconfWhitelist {
     /// @param _list   Wildcard array to remove from — `fromWildcards` or `toWildcards`.
     /// @param _idxMap That array's membership index, rewritten for the swapped-in element.
     /// @param _addr   Address to revoke.
-    function _rmWildcard(address[] storage _list, mapping(address => uint256) storage _idxMap, address _addr) internal {
+    function _rmWildcard(
+        address[] storage _list,
+        mapping(address => uint256) storage _idxMap,
+        address _addr
+    )
+        internal
+    {
         uint256 idx = _idxMap[_addr];
         if (idx == 0) return;
         uint256 i = idx - 1;

--- a/packages/contracts-bedrock/test/PreconfWhitelist.t.sol
+++ b/packages/contracts-bedrock/test/PreconfWhitelist.t.sol
@@ -463,7 +463,8 @@ contract PreconfWhitelist_Test is Portal_Initializer {
         out_ = new PreconfWhitelist.Rule[](_n);
         for (uint256 i = 0; i < _n; i++) {
             out_[i] = PreconfWhitelist.Rule({
-                from: address(uint160(_seed + i + 1)), to: address(uint160(_seed + i + 0x100000))
+                from: address(uint160(_seed + i + 1)),
+                to: address(uint160(_seed + i + 0x100000))
             });
         }
     }

--- a/packages/contracts-bedrock/test/PreconfWhitelist.t.sol
+++ b/packages/contracts-bedrock/test/PreconfWhitelist.t.sol
@@ -747,18 +747,23 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
 
     // ===== MAX_BATCH sizing =====
     //
-    // `MAX_BATCH = 330` is not a round number picked for looks: it is calibrated so that a full
-    // batch of the most expensive rule form stays under the ~23M gas a governance message has to
-    // fit in. That justification lives entirely in the two measurements below, so they assert a
-    // ceiling rather than only logging. A change that inflates per-rule cost has to either stay
-    // under the bound or force whoever made it to re-derive `MAX_BATCH` — which is the point.
+    // `MAX_BATCH = 256` is calibrated so that a full batch of the most expensive rule form fits in
+    // the gas a governance message can actually be given. That budget comes from **L1**, not from
+    // the L2 block: `OptimismPortal.depositTransaction` is `metered`, so `ResourceMetering` caps the
+    // deposit gas bought per L1 block at `maxResourceLimit` (20,000,000), and
+    // `CrossDomainMessenger.baseGas` spends 683,088 of it on overhead before the EIP-150 63/64 term
+    // — leaving 19,015,085 of `_minGasLimit`. The full derivation is on `MAX_BATCH` in
+    // `PreconfWhitelist.sol`; extrapolating the two figures below puts the hard ceiling near 276.
     //
-    // The bounds are deliberately loose (about 2.5% of headroom over the recorded figures), so
-    // compiler-version noise does not turn them into a tripwire. Run with `-vv` to read the
-    // numbers; if a bound trips, re-measure and update the table in `PreconfWhitelist.sol`.
+    // That justification lives entirely in the two measurements below, so they assert the ceiling
+    // rather than only logging. A change that inflates per-rule cost has to either stay under the
+    // bound or force whoever made it to re-derive `MAX_BATCH` — which is the point. The pair bound
+    // is the real 19,015,085 figure, which sits 7% above the recorded cost, so compiler-version
+    // noise is not a tripwire. Run with `-vv` to read the numbers; if a bound trips, re-measure and
+    // update the table in `PreconfWhitelist.sol`.
 
     /// @notice A full `MAX_BATCH` of exact-pair adds — the expensive form `MAX_BATCH` is sized
-    ///         against. Recorded at 22,446,092 (68,018 per rule).
+    ///         against. Recorded at 17,689,309 (69,098 per rule).
     function test_gas_maxBatchOfPairAdds() external {
         uint256 max = wl.MAX_BATCH();
         PreconfWhitelist.Rule[] memory adds = _pairBatch(max, 0);
@@ -772,11 +777,11 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
         console.log("gas, all pair adds    ", used);
         console.log("gas per pair add      ", used / max);
 
-        assertLt(used, 23_000_000, "MAX_BATCH is calibrated against a ~23M ceiling -- re-derive it");
+        assertLt(used, 19_015_085, "a full batch must fit in the _minGasLimit L1 can pay for -- re-derive MAX_BATCH");
     }
 
     /// @notice The same batch made entirely of wildcards, to confirm the pair form really is the
-    ///         expensive one. Recorded at 15,074,717 (45,680 per rule).
+    ///         expensive one. Recorded at 11,941,833 (46,647 per rule).
     /// @dev    Bounded above by the pair figure as well as by an absolute number: if a wildcard add
     ///         ever became the costlier of the two, `MAX_BATCH` would be sized against the wrong
     ///         operation and the ceiling above would stop being an upper bound at all.
@@ -795,7 +800,7 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
         console.log("gas, all wildcard adds", used);
         console.log("gas per wildcard add  ", used / max);
 
-        assertLt(used, 15_500_000, "wildcard adds got more expensive -- re-measure");
-        assertLt(used, 22_446_092, "the exact-pair form must stay the expensive one");
+        assertLt(used, 12_300_000, "wildcard adds got more expensive -- re-measure");
+        assertLt(used, 17_689_309, "the exact-pair form must stay the expensive one");
     }
 }

--- a/packages/contracts-bedrock/test/PreconfWhitelist.t.sol
+++ b/packages/contracts-bedrock/test/PreconfWhitelist.t.sol
@@ -43,14 +43,14 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
     }
 
     /// @notice Single-element rule array.
-    function _one(address _from, address _to) internal pure returns (PreconfWhitelist.Rule[] memory out) {
-        out = new PreconfWhitelist.Rule[](1);
-        out[0] = _p(_from, _to);
+    function _one(address _from, address _to) internal pure returns (PreconfWhitelist.Rule[] memory out_) {
+        out_ = new PreconfWhitelist.Rule[](1);
+        out_[0] = _p(_from, _to);
     }
 
     /// @notice Empty rule array.
-    function _none() internal pure returns (PreconfWhitelist.Rule[] memory out) {
-        out = new PreconfWhitelist.Rule[](0);
+    function _none() internal pure returns (PreconfWhitelist.Rule[] memory out_) {
+        out_ = new PreconfWhitelist.Rule[](0);
     }
 
     /// @notice Makes the next call look like a relayed cross-domain message from `sender`.
@@ -499,12 +499,11 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
 
     /// @notice Builds `_n` distinct exact pairs — the most expensive rule form, which is what
     ///         `MAX_BATCH` is sized against.
-    function _pairBatch(uint256 _n, uint256 _seed) internal pure returns (PreconfWhitelist.Rule[] memory out) {
-        out = new PreconfWhitelist.Rule[](_n);
+    function _pairBatch(uint256 _n, uint256 _seed) internal pure returns (PreconfWhitelist.Rule[] memory out_) {
+        out_ = new PreconfWhitelist.Rule[](_n);
         for (uint256 i = 0; i < _n; i++) {
-            out[i] = PreconfWhitelist.Rule({
-                from: address(uint160(_seed + i + 1)),
-                to: address(uint160(_seed + i + 0x100000))
+            out_[i] = PreconfWhitelist.Rule({
+                from: address(uint160(_seed + i + 1)), to: address(uint160(_seed + i + 0x100000))
             });
         }
     }

--- a/packages/contracts-bedrock/test/PreconfWhitelist.t.sol
+++ b/packages/contracts-bedrock/test/PreconfWhitelist.t.sol
@@ -503,7 +503,8 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
         out_ = new PreconfWhitelist.Rule[](_n);
         for (uint256 i = 0; i < _n; i++) {
             out_[i] = PreconfWhitelist.Rule({
-                from: address(uint160(_seed + i + 1)), to: address(uint160(_seed + i + 0x100000))
+                from: address(uint160(_seed + i + 1)),
+                to: address(uint160(_seed + i + 0x100000))
             });
         }
     }

--- a/packages/contracts-bedrock/test/PreconfWhitelist.t.sol
+++ b/packages/contracts-bedrock/test/PreconfWhitelist.t.sol
@@ -2,9 +2,9 @@
 pragma solidity 0.8.15;
 
 import { console } from "forge-std/console.sol";
+import { Vm } from "forge-std/Vm.sol";
 import { Messenger_Initializer } from "./CommonTest.t.sol";
 import { CrossDomainMessenger } from "src/universal/CrossDomainMessenger.sol";
-import { Predeploys } from "src/libraries/Predeploys.sol";
 import { PreconfWhitelist } from "src/L2/PreconfWhitelist.sol";
 
 /// @title PreconfWhitelist_Test
@@ -24,12 +24,12 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
 
     PreconfWhitelist internal wl;
 
-    event WhitelistUpdated(uint256 pairCount, uint256 fromWildcardCount, uint256 toWildcardCount);
+    event WhitelistUpdated(uint256 exactPairCount, uint256 fromWildcardCount, uint256 toWildcardCount);
 
     function setUp() public virtual override {
         super.setUp();
         // One of each form, so every test starts from a state that exercises all three sets.
-        PreconfWhitelist.Pair[] memory seed = new PreconfWhitelist.Pair[](3);
+        PreconfWhitelist.Rule[] memory seed = new PreconfWhitelist.Rule[](3);
         seed[0] = _p(P_FROM, P_TO);
         seed[1] = _p(FW, address(0));
         seed[2] = _p(address(0), TW);
@@ -38,19 +38,19 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
 
     // ===== helpers =====
 
-    function _p(address _from, address _to) internal pure returns (PreconfWhitelist.Pair memory) {
-        return PreconfWhitelist.Pair({ from: _from, to: _to });
+    function _p(address _from, address _to) internal pure returns (PreconfWhitelist.Rule memory) {
+        return PreconfWhitelist.Rule({ from: _from, to: _to });
     }
 
     /// @notice Single-element rule array.
-    function _one(address _from, address _to) internal pure returns (PreconfWhitelist.Pair[] memory out) {
-        out = new PreconfWhitelist.Pair[](1);
+    function _one(address _from, address _to) internal pure returns (PreconfWhitelist.Rule[] memory out) {
+        out = new PreconfWhitelist.Rule[](1);
         out[0] = _p(_from, _to);
     }
 
     /// @notice Empty rule array.
-    function _none() internal pure returns (PreconfWhitelist.Pair[] memory out) {
-        out = new PreconfWhitelist.Pair[](0);
+    function _none() internal pure returns (PreconfWhitelist.Rule[] memory out) {
+        out = new PreconfWhitelist.Rule[](0);
     }
 
     /// @notice Makes the next call look like a relayed cross-domain message from `sender`.
@@ -62,7 +62,7 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
     }
 
     /// @notice `updatePreconfs` as the authorized L1 governor.
-    function _gov(PreconfWhitelist.Pair[] memory _add, PreconfWhitelist.Pair[] memory _remove) internal {
+    function _gov(PreconfWhitelist.Rule[] memory _add, PreconfWhitelist.Rule[] memory _remove) internal {
         _asCrossDomain(AUTHORIZED_L1);
         wl.updatePreconfs(_add, _remove);
     }
@@ -73,14 +73,32 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
     }
 
     function _counts() internal view returns (uint256, uint256, uint256) {
-        return (wl.pairsLength(), wl.fromWildcardsLength(), wl.toWildcardsLength());
+        return (wl.exactPairsLength(), wl.fromWildcardsLength(), wl.toWildcardsLength());
+    }
+
+    /// @notice Adds two exact pairs, one sender wildcard and two recipient wildcards on top of
+    ///         `setUp`'s one-of-each, leaving the three sets at **3 / 2 / 3**. The sizes are
+    ///         deliberately distinct: a getter that sliced the wrong bounds cannot then pass by
+    ///         symmetry. The resulting concatenation, which `getAllRules` and `getRules` share, is
+    ///
+    ///           0..2  exact    (P_FROM,P_TO) (0xA1,0xB1) (0xA2,0xB2)
+    ///           3..4  sender    FW           0xF1
+    ///           5..7  recipient TW           0xD1        0xD2
+    function _seedMixed() internal {
+        PreconfWhitelist.Rule[] memory add = new PreconfWhitelist.Rule[](5);
+        add[0] = _p(address(0xA1), address(0xB1));
+        add[1] = _p(address(0xA2), address(0xB2));
+        add[2] = _p(address(0xF1), address(0));
+        add[3] = _p(address(0), address(0xD1));
+        add[4] = _p(address(0), address(0xD2));
+        _gov(add, _none());
     }
 
     // ===== constructor / seeding =====
 
     function test_constructor_seedsAllThreeForms_succeeds() external view {
         assertEq(wl.AUTHORIZED_L1(), AUTHORIZED_L1);
-        assertTrue(wl.isWhitelistPair(P_FROM, P_TO));
+        assertTrue(wl.isExactPair(P_FROM, P_TO));
         assertTrue(wl.isFromWildcard(FW));
         assertTrue(wl.isToWildcard(TW));
         (uint256 p, uint256 f, uint256 t) = _counts();
@@ -90,7 +108,7 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
     }
 
     function test_constructor_emitsWhitelistUpdated_succeeds() external {
-        PreconfWhitelist.Pair[] memory seed = new PreconfWhitelist.Pair[](2);
+        PreconfWhitelist.Rule[] memory seed = new PreconfWhitelist.Rule[](2);
         seed[0] = _p(address(0xAA), address(0xBB));
         seed[1] = _p(address(0xCC), address(0));
 
@@ -114,11 +132,11 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
     // ===== routing: the three forms =====
 
     /// @notice A rule with both halves set is an exact pair and touches neither wildcard set.
-    function test_updatePreconfs_exactPair_routesToPairs_succeeds() external {
+    function test_updatePreconfs_exactPair_routesToExactPairs_succeeds() external {
         _gov(_one(address(0x5555), address(0x6666)), _none());
 
-        assertTrue(wl.isWhitelistPair(address(0x5555), address(0x6666)));
-        assertFalse(wl.isWhitelistPair(address(0x6666), address(0x5555)), "direction matters");
+        assertTrue(wl.isExactPair(address(0x5555), address(0x6666)));
+        assertFalse(wl.isExactPair(address(0x6666), address(0x5555)), "direction matters");
         assertFalse(wl.isFromWildcard(address(0x5555)));
         assertFalse(wl.isToWildcard(address(0x6666)));
         (uint256 p, uint256 f, uint256 t) = _counts();
@@ -171,12 +189,12 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
     ///         sequencer's predicate honest — see the contract docs.
     function test_pairAndWildcardCoexist_succeeds() external {
         _gov(_one(FW, address(0x7777)), _none());
-        assertTrue(wl.isWhitelistPair(FW, address(0x7777)));
+        assertTrue(wl.isExactPair(FW, address(0x7777)));
         assertTrue(wl.isFromWildcard(FW));
 
         // Revoking the exact rule does not revoke the wildcard that also covers it.
         _gov(_none(), _one(FW, address(0x7777)));
-        assertFalse(wl.isWhitelistPair(FW, address(0x7777)));
+        assertFalse(wl.isExactPair(FW, address(0x7777)));
         assertTrue(wl.isFromWildcard(FW), "the wildcard still authorizes this traffic");
     }
 
@@ -221,7 +239,7 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
         assertTrue(wl.isWhitelist(FW, address(0x7777)));
 
         _gov(_none(), _one(FW, address(0x7777)));
-        assertFalse(wl.isWhitelistPair(FW, address(0x7777)), "the exact rule is gone");
+        assertFalse(wl.isExactPair(FW, address(0x7777)), "the exact rule is gone");
         assertTrue(wl.isWhitelist(FW, address(0x7777)), "but the sender wildcard still authorizes it");
 
         _gov(_none(), _one(FW, address(0)));
@@ -237,13 +255,13 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
     // ===== add / remove semantics =====
 
     function test_updatePreconfs_removeAcrossAllThreeSets_succeeds() external {
-        PreconfWhitelist.Pair[] memory rm = new PreconfWhitelist.Pair[](3);
+        PreconfWhitelist.Rule[] memory rm = new PreconfWhitelist.Rule[](3);
         rm[0] = _p(P_FROM, P_TO);
         rm[1] = _p(FW, address(0));
         rm[2] = _p(address(0), TW);
         _gov(_none(), rm);
 
-        assertFalse(wl.isWhitelistPair(P_FROM, P_TO));
+        assertFalse(wl.isExactPair(P_FROM, P_TO));
         assertFalse(wl.isFromWildcard(FW));
         assertFalse(wl.isToWildcard(TW));
         (uint256 p, uint256 f, uint256 t) = _counts();
@@ -261,18 +279,18 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
     /// @notice Adds are applied before removes, so a rule in both arguments ends up removed.
     function test_updatePreconfs_addThenRemoveSamePair_succeeds() external {
         _gov(_one(address(0x5555), address(0x6666)), _one(address(0x5555), address(0x6666)));
-        assertFalse(wl.isWhitelistPair(address(0x5555), address(0x6666)));
+        assertFalse(wl.isExactPair(address(0x5555), address(0x6666)));
     }
 
     function test_updatePreconfs_addExisting_isNoop() external {
         _gov(_one(P_FROM, P_TO), _none());
         (uint256 p,,) = _counts();
         assertEq(p, 1);
-        assertTrue(wl.isWhitelistPair(P_FROM, P_TO));
+        assertTrue(wl.isExactPair(P_FROM, P_TO));
     }
 
     function test_updatePreconfs_removeAbsent_isNoop() external {
-        PreconfWhitelist.Pair[] memory rm = new PreconfWhitelist.Pair[](3);
+        PreconfWhitelist.Rule[] memory rm = new PreconfWhitelist.Rule[](3);
         rm[0] = _p(address(0xDEAD), address(0xBEEF));
         rm[1] = _p(address(0xDEAD), address(0));
         rm[2] = _p(address(0), address(0xBEEF));
@@ -284,48 +302,54 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
         assertEq(t, 1);
     }
 
-    /// @notice Swap-and-pop must keep `pairIndex` in step for the element that moved. Removing a
+    /// @notice Swap-and-pop must keep `exactPairIndex` in step for the element that moved. Removing a
     ///         *middle* element is the only case that exercises the swap; removing the last one
     ///         takes a degenerate path where the element is swapped with itself.
-    function test_removePair_swapPop_keepsIndexInStep_succeeds() external {
-        PreconfWhitelist.Pair[] memory add = new PreconfWhitelist.Pair[](2);
+    function test_rmExactPair_swapPop_keepsIndexInStep_succeeds() external {
+        PreconfWhitelist.Rule[] memory add = new PreconfWhitelist.Rule[](2);
         add[0] = _p(address(0xA1), address(0xB1));
         add[1] = _p(address(0xA2), address(0xB2));
-        _gov(add, _none()); // pairs = [seed, A1B1, A2B2]
+        _gov(add, _none()); // exactPairs = [seed, A1B1, A2B2]
 
         _gov(_none(), _one(address(0xA1), address(0xB1))); // remove the middle one
 
         (uint256 p,,) = _counts();
         assertEq(p, 2);
-        assertFalse(wl.isWhitelistPair(address(0xA1), address(0xB1)));
-        assertTrue(wl.isWhitelistPair(address(0xA2), address(0xB2)), "the moved element stays indexed");
+        assertFalse(wl.isExactPair(address(0xA1), address(0xB1)));
+        assertTrue(wl.isExactPair(address(0xA2), address(0xB2)), "the moved element stays indexed");
         // And its recorded position must be the one it actually occupies now.
-        assertEq(wl.pairIndex(address(0xA2), address(0xB2)), 2);
-        (address f, address t) = wl.pairs(1);
+        assertEq(wl.exactPairIndex(address(0xA2), address(0xB2)), 2);
+        (address f, address t) = wl.exactPairs(1);
         assertEq(f, address(0xA2));
         assertEq(t, address(0xB2));
     }
 
     /// @notice Removing the final element: the swap writes it over itself, so the subsequent
     ///         `delete` is what actually clears the index. A guard against "restore then forget".
-    function test_removePair_lastElement_succeeds() external {
+    function test_rmExactPair_lastElement_succeeds() external {
         _gov(_one(address(0xA1), address(0xB1)), _none());
         _gov(_none(), _one(address(0xA1), address(0xB1)));
 
         (uint256 p,,) = _counts();
         assertEq(p, 1);
-        assertFalse(wl.isWhitelistPair(address(0xA1), address(0xB1)));
-        assertEq(wl.pairIndex(address(0xA1), address(0xB1)), 0);
+        assertFalse(wl.isExactPair(address(0xA1), address(0xB1)));
+        assertEq(wl.exactPairIndex(address(0xA1), address(0xB1)), 0);
     }
 
     // ===== authorization: design doc §5.2 attacks B and C =====
 
-    /// @notice Attack B — deposit aimed straight at this contract, bypassing the messenger.
+    /// @notice Attack B — deposit aimed straight at this contract, bypassing the messenger. This is
+    ///         the negative face of gate 1.
+    /// @dev    The positive face — that the contract's hardcoded `MESSENGER` literal really is
+    ///         `Predeploys.L2_CROSS_DOMAIN_MESSENGER` — needs no test of its own. `L2Messenger` is
+    ///         declared *as* that predeploy in `CommonTest.t.sol`, and gate 1 admits only
+    ///         `msg.sender == MESSENGER`, so every passing `_gov` call in this file already proves
+    ///         the two are equal. A separate `assertEq(Predeploys.X, 0x42..07)` would assert
+    ///         nothing about this contract, since `MESSENGER` is `internal` and unreachable here.
     function test_updatePreconfs_notMessenger_reverts() external {
         vm.prank(alice);
         vm.expectRevert("PreconfWhitelist: caller is not the messenger");
         wl.updatePreconfs(_one(address(0x9999), address(0x8888)), _none());
-        assertFalse(wl.isWhitelistPair(address(0x9999), address(0x8888)));
     }
 
     /// @notice Attack C — a legitimate but unauthorized L1 caller relaying through the messenger.
@@ -333,7 +357,6 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
         _asCrossDomain(alice);
         vm.expectRevert("PreconfWhitelist: caller is not the authorized L1 sender");
         wl.updatePreconfs(_one(address(0x9999), address(0x8888)), _none());
-        assertFalse(wl.isWhitelistPair(address(0x9999), address(0x8888)));
     }
 
     /// @notice The messenger address itself is not privileged — reaching us with a zero
@@ -348,10 +371,10 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
 
     /// @notice Builds `_n` distinct exact pairs — the most expensive rule form, which is what
     ///         `MAX_BATCH` is sized against.
-    function _pairBatch(uint256 _n, uint256 _seed) internal pure returns (PreconfWhitelist.Pair[] memory out) {
-        out = new PreconfWhitelist.Pair[](_n);
+    function _pairBatch(uint256 _n, uint256 _seed) internal pure returns (PreconfWhitelist.Rule[] memory out) {
+        out = new PreconfWhitelist.Rule[](_n);
         for (uint256 i = 0; i < _n; i++) {
-            out[i] = PreconfWhitelist.Pair({
+            out[i] = PreconfWhitelist.Rule({
                 from: address(uint160(_seed + i + 1)),
                 to: address(uint160(_seed + i + 0x100000))
             });
@@ -372,7 +395,7 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
     ///         and the `vm.expectRevert`, leaving the test to assert against the wrong call. That
     ///         mistake passes as a green test, so it is worth the extra line.
     function test_updatePreconfs_overMaxBatch_revertsAndChangesNothing() external {
-        PreconfWhitelist.Pair[] memory over = _pairBatch(wl.MAX_BATCH() + 1, 0);
+        PreconfWhitelist.Rule[] memory over = _pairBatch(wl.MAX_BATCH() + 1, 0);
 
         _asCrossDomain(AUTHORIZED_L1);
         vm.expectRevert("PreconfWhitelist: batch too large");
@@ -394,25 +417,25 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
 
     // ===== pagination =====
 
-    function test_getPairs_paging_succeeds() external {
+    function test_getExactPairs_paging_succeeds() external {
         _gov(_pairBatch(4, 0), _none()); // 5 total, including the seed
 
-        assertEq(wl.pairsLength(), 5);
-        assertEq(wl.getPairs(0, 2).length, 2, "a full page");
-        assertEq(wl.getPairs(4, 10).length, 1, "an over-long limit truncates to the end");
-        assertEq(wl.getPairs(5, 10).length, 0, "offset == length is empty, not a revert");
-        assertEq(wl.getPairs(99, 10).length, 0, "offset past the end is empty, not a revert");
-        assertEq(wl.getPairs(0, type(uint256).max).length, 5, "the limit must not overflow");
+        assertEq(wl.exactPairsLength(), 5);
+        assertEq(wl.getExactPairs(0, 2).length, 2, "a full page");
+        assertEq(wl.getExactPairs(4, 10).length, 1, "an over-long limit truncates to the end");
+        assertEq(wl.getExactPairs(5, 10).length, 0, "offset == length is empty, not a revert");
+        assertEq(wl.getExactPairs(99, 10).length, 0, "offset past the end is empty, not a revert");
+        assertEq(wl.getExactPairs(0, type(uint256).max).length, 5, "the limit must not overflow");
     }
 
     /// @notice The page contents must line up with the underlying indices, or a caller walking the
     ///         list would silently skip or repeat rules.
-    function test_getPairs_pageContents_succeeds() external {
+    function test_getExactPairs_pageContents_succeeds() external {
         _gov(_pairBatch(4, 0), _none());
 
-        PreconfWhitelist.Pair[] memory page = wl.getPairs(1, 2);
-        (address f1, address t1) = wl.pairs(1);
-        (address f2, address t2) = wl.pairs(2);
+        PreconfWhitelist.Rule[] memory page = wl.getExactPairs(1, 2);
+        (address f1, address t1) = wl.exactPairs(1);
+        (address f2, address t2) = wl.exactPairs(2);
         assertEq(page[0].from, f1);
         assertEq(page[0].to, t1);
         assertEq(page[1].from, f2);
@@ -420,7 +443,7 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
     }
 
     function test_getWildcards_paging_succeeds() external {
-        PreconfWhitelist.Pair[] memory add = new PreconfWhitelist.Pair[](4);
+        PreconfWhitelist.Rule[] memory add = new PreconfWhitelist.Rule[](4);
         add[0] = _p(address(0xF1), address(0));
         add[1] = _p(address(0xF2), address(0));
         add[2] = _p(address(0), address(0xD1));
@@ -433,12 +456,208 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
         assertEq(wl.getToWildcards(0, type(uint256).max).length, 3, "the limit must not overflow");
     }
 
+    // ===== full-list getters =====
+
+    /// @notice An empty allowlist yields empty arrays rather than a revert, so tooling does not
+    ///         have to special-case a fresh deployment.
+    function test_getAll_emptyAllowlist_returnsEmptyArrays_succeeds() external {
+        PreconfWhitelist fresh = new PreconfWhitelist(AUTHORIZED_L1, _none());
+        assertEq(fresh.getAllExactPairs().length, 0);
+        assertEq(fresh.getAllFromWildcards().length, 0);
+        assertEq(fresh.getAllToWildcards().length, 0);
+        assertEq(fresh.getAllRules().length, 0);
+    }
+
+    /// @notice The unbounded getter and the paginated one are two views of the same array, and a
+    ///         caller that outgrows the former is expected to switch to the latter — so they have
+    ///         to agree element for element, not just in length.
+    function test_getAllExactPairs_agreesWithPaging_succeeds() external {
+        _gov(_pairBatch(4, 0), _none()); // 5 total, including the seed
+
+        PreconfWhitelist.Rule[] memory all = wl.getAllExactPairs();
+        assertEq(all.length, wl.exactPairsLength(), "length matches the counter");
+        assertEq(all.length, 5);
+
+        PreconfWhitelist.Rule[] memory page = wl.getExactPairs(0, type(uint256).max);
+        for (uint256 i = 0; i < all.length; i++) {
+            assertEq(all[i].from, page[i].from);
+            assertEq(all[i].to, page[i].to);
+        }
+    }
+
+    /// @notice Same agreement for the two wildcard sets. Their sizes are made to differ so a
+    ///         getter reading the wrong array cannot pass by coincidence.
+    function test_getAllWildcards_agreeWithPaging_succeeds() external {
+        PreconfWhitelist.Rule[] memory add = new PreconfWhitelist.Rule[](3);
+        add[0] = _p(address(0xF1), address(0));
+        add[1] = _p(address(0), address(0xD1));
+        add[2] = _p(address(0), address(0xD2));
+        _gov(add, _none()); // 2 sender wildcards, 3 recipient wildcards
+
+        address[] memory allFrom = wl.getAllFromWildcards();
+        address[] memory allTo = wl.getAllToWildcards();
+        assertEq(allFrom.length, 2);
+        assertEq(allTo.length, 3);
+
+        address[] memory pageFrom = wl.getFromWildcards(0, type(uint256).max);
+        address[] memory pageTo = wl.getToWildcards(0, type(uint256).max);
+        for (uint256 i = 0; i < allFrom.length; i++) {
+            assertEq(allFrom[i], pageFrom[i]);
+        }
+        for (uint256 i = 0; i < allTo.length; i++) {
+            assertEq(allTo[i], pageTo[i]);
+        }
+    }
+
+    /// @notice `getAllRules` is the three sets concatenated in declaration order, with wildcards
+    ///         re-encoded into the zero-address wire form. That layout is part of the interface,
+    ///         not an implementation detail: exact pairs first, then sender wildcards as `(A, 0)`,
+    ///         then recipient wildcards as `(0, B)`.
+    function test_getAllRules_concatenatesThreeSetsInOrder_succeeds() external view {
+        PreconfWhitelist.Rule[] memory all = wl.getAllRules();
+        assertEq(all.length, 3, "one of each seeded form");
+
+        assertEq(all[0].from, P_FROM, "exact pairs come first");
+        assertEq(all[0].to, P_TO);
+
+        assertEq(all[1].from, FW, "then sender wildcards, as (A, 0)");
+        assertEq(all[1].to, address(0));
+
+        assertEq(all[2].from, address(0), "then recipient wildcards, as (0, B)");
+        assertEq(all[2].to, TW);
+    }
+
+    /// @notice The length is the sum of all three sets — and, just as much, a guard on the
+    ///         `_seedMixed` fixture itself. `test_getRules_pageStraddlingBothBoundaries_succeeds`
+    ///         hardcodes indices read off the 3 / 2 / 3 layout, so if that helper ever drifts, this
+    ///         is where it should surface rather than as a puzzling failure over there.
+    function test_getAllRules_lengthIsSumOfThreeSets_succeeds() external {
+        _seedMixed();
+
+        assertEq(wl.exactPairsLength(), 3);
+        assertEq(wl.fromWildcardsLength(), 2);
+        assertEq(wl.toWildcardsLength(), 3);
+        assertEq(wl.getAllRules().length, 8);
+    }
+
+    /// @notice The documented migration path: `getAllRules()` output is valid constructor and
+    ///         `updatePreconfs` input, so an allowlist can be cloned onto a fresh deployment with
+    ///         no off-chain reassembly. This is what makes a `LAYOUT_VERSION` bump survivable.
+    ///
+    ///         The clone's constructor also doubles as an assertion that the output never contains
+    ///         an all-zero rule: `_apply` reverts on that form, so an emitted `(0, 0)` would fail
+    ///         this test rather than silently disappear.
+    function test_getAllRules_roundTripsIntoAFreshDeployment_succeeds() external {
+        _seedMixed();
+
+        PreconfWhitelist.Rule[] memory all = wl.getAllRules();
+        PreconfWhitelist clone = new PreconfWhitelist(AUTHORIZED_L1, all);
+
+        assertEq(clone.exactPairsLength(), wl.exactPairsLength());
+        assertEq(clone.fromWildcardsLength(), wl.fromWildcardsLength());
+        assertEq(clone.toWildcardsLength(), wl.toWildcardsLength());
+
+        // Counts alone would survive a wildcard that came back with the wrong half zeroed, so
+        // check that every rule landed in the set it came from.
+        for (uint256 i = 0; i < all.length; i++) {
+            if (all[i].from == address(0)) {
+                assertTrue(clone.isToWildcard(all[i].to), "recipient wildcard");
+            } else if (all[i].to == address(0)) {
+                assertTrue(clone.isFromWildcard(all[i].from), "sender wildcard");
+            } else {
+                assertTrue(clone.isExactPair(all[i].from, all[i].to), "exact pair");
+            }
+        }
+    }
+
+    /// @notice `getRules` pages over the same concatenation `getAllRules` returns, so walking it
+    ///         one element at a time has to reproduce that array exactly. Stepping by one puts
+    ///         every index — including both segment boundaries — in its own call, which is where
+    ///         an off-by-one in the index mapping would show up.
+    function test_getRules_pagingReproducesGetAllRules_succeeds() external {
+        _seedMixed();
+
+        PreconfWhitelist.Rule[] memory all = wl.getAllRules();
+        assertEq(all.length, 8);
+
+        for (uint256 i = 0; i < all.length; i++) {
+            PreconfWhitelist.Rule[] memory one = wl.getRules(i, 1);
+            assertEq(one.length, 1);
+            assertEq(one[0].from, all[i].from, "from at index");
+            assertEq(one[0].to, all[i].to, "to at index");
+        }
+    }
+
+    /// @notice One page straddling both segment boundaries at once. Indices are read off the
+    ///         3 / 2 / 3 layout documented on `_seedMixed`: 2 is the last exact pair, 3 and 4 the
+    ///         sender wildcards, 5 the first recipient one. A segment-mapping error cannot survive
+    ///         a page that crosses both.
+    function test_getRules_pageStraddlingBothBoundaries_succeeds() external {
+        _seedMixed();
+
+        PreconfWhitelist.Rule[] memory page = wl.getRules(2, 4);
+        assertEq(page.length, 4);
+
+        assertEq(page[0].from, address(0xA2), "index 2: last exact pair");
+        assertEq(page[0].to, address(0xB2));
+
+        assertEq(page[1].from, FW, "index 3: first sender wildcard, as (A, 0)");
+        assertEq(page[1].to, address(0));
+
+        assertEq(page[2].from, address(0xF1), "index 4: second sender wildcard");
+        assertEq(page[2].to, address(0));
+
+        assertEq(page[3].from, address(0), "index 5: first recipient wildcard, as (0, B)");
+        assertEq(page[3].to, TW);
+    }
+
+    /// @notice The boundary behaviour matches the per-set paginated getters: out-of-range offsets
+    ///         yield an empty array rather than reverting, and an over-long limit truncates.
+    function test_getRules_pagingEdgeCases_succeeds() external {
+        _seedMixed(); // 8 rules in total
+
+        assertEq(wl.getRules(0, 3).length, 3, "a full page");
+        assertEq(wl.getRules(6, 10).length, 2, "an over-long limit truncates to the end");
+        assertEq(wl.getRules(8, 10).length, 0, "offset == total is empty, not a revert");
+        assertEq(wl.getRules(99, 10).length, 0, "offset past the end is empty, not a revert");
+        assertEq(wl.getRules(0, type(uint256).max).length, 8, "the limit must not overflow");
+        assertEq(wl.getRules(0, 0).length, 0, "a zero limit is an empty page");
+    }
+
+    /// @notice An empty allowlist pages to an empty array. The total is a sum of three lengths, so
+    ///         this also covers the case where every segment is empty at once.
+    function test_getRules_emptyAllowlist_returnsEmptyArray_succeeds() external {
+        PreconfWhitelist fresh = new PreconfWhitelist(AUTHORIZED_L1, _none());
+        assertEq(fresh.getRules(0, 10).length, 0);
+    }
+
+    /// @notice `rulesLength` is the bound for `getRules` and the size check to make before calling
+    ///         `getAllRules`, so it has to agree with both — a counter that drifts from what the
+    ///         getters actually return would send a caller past the end or into the gas cliff it
+    ///         was consulted to avoid.
+    function test_rulesLength_agreesWithTheSetsAndGetAllRules_succeeds() external {
+        assertEq(wl.rulesLength(), 3, "the seeded one-of-each");
+
+        _seedMixed();
+
+        (uint256 p, uint256 f, uint256 t) = _counts();
+        assertEq(wl.rulesLength(), p + f + t, "the sum of the three sets");
+        assertEq(wl.rulesLength(), wl.getAllRules().length, "the length getAllRules returns");
+        assertEq(wl.getRules(wl.rulesLength(), 1).length, 0, "it is exactly the exclusive bound");
+    }
+
+    /// @notice Zero on an empty allowlist rather than a revert, matching the per-set counters.
+    function test_rulesLength_emptyAllowlist_isZero_succeeds() external {
+        PreconfWhitelist fresh = new PreconfWhitelist(AUTHORIZED_L1, _none());
+        assertEq(fresh.rulesLength(), 0);
+    }
+
     // ===== op-reth coupling: storage layout + event topic =====
 
     /// @notice op-reth reads these slots directly. If this test fails, the Rust constants in
     ///         `mantle-reth/crates/preconf/src/whitelist.rs` must change in lockstep.
     ///
-    ///         The `pairs` assertions also pin the **two-slot element stride**, which is the whole
+    ///         The `exactPairs` assertions also pin the **two-slot element stride**, which is the whole
     ///         basis of the Rust reader's `base + 2i` / `base + 2i + 1` addressing. Two addresses
     ///         are 40 bytes and cannot share a slot; this proves the compiler agrees at runtime,
     ///         rather than leaving it to a reading of the layout rules.
@@ -446,15 +665,15 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
         _gov(_one(address(0xA9), address(0xB9)), _none()); // a second pair, so the stride shows
 
         // Array lengths live at the declaring slot.
-        assertEq(uint256(vm.load(address(wl), bytes32(uint256(0)))), 2, "pairs must be slot 0");
+        assertEq(uint256(vm.load(address(wl), bytes32(uint256(0)))), 2, "exactPairs must be slot 0");
         assertEq(uint256(vm.load(address(wl), bytes32(uint256(2)))), 1, "fromWildcards must be slot 2");
         assertEq(uint256(vm.load(address(wl), bytes32(uint256(4)))), 1, "toWildcards must be slot 4");
 
         bytes32 pairsBase = keccak256(abi.encode(uint256(0)));
-        assertEq(_addrAt(pairsBase, 0), P_FROM, "pairs[0].from at base+0");
-        assertEq(_addrAt(pairsBase, 1), P_TO, "pairs[0].to at base+1");
-        assertEq(_addrAt(pairsBase, 2), address(0xA9), "pairs[1].from at base+2 -- the 2-slot stride");
-        assertEq(_addrAt(pairsBase, 3), address(0xB9), "pairs[1].to at base+3");
+        assertEq(_addrAt(pairsBase, 0), P_FROM, "exactPairs[0].from at base+0");
+        assertEq(_addrAt(pairsBase, 1), P_TO, "exactPairs[0].to at base+1");
+        assertEq(_addrAt(pairsBase, 2), address(0xA9), "exactPairs[1].from at base+2 -- the 2-slot stride");
+        assertEq(_addrAt(pairsBase, 3), address(0xB9), "exactPairs[1].to at base+3");
 
         assertEq(_addrAt(keccak256(abi.encode(uint256(2))), 0), FW, "fromWildcards[0]");
         assertEq(_addrAt(keccak256(abi.encode(uint256(4))), 0), TW, "toWildcards[0]");
@@ -462,10 +681,10 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
 
     /// @notice The three index mappings sit immediately after their arrays, at slots 1, 3 and 5.
     ///         This pins the whole 0..5 block so an inserted variable cannot slide the arrays
-    ///         unnoticed. `pairIndex` is nested, so its slot is a double hash.
+    ///         unnoticed. `exactPairIndex` is nested, so its slot is a double hash.
     function test_storageLayout_indexMappingSlots_succeeds() external view {
         bytes32 inner = keccak256(abi.encode(P_FROM, uint256(1)));
-        assertEq(uint256(vm.load(address(wl), keccak256(abi.encode(P_TO, inner)))), 1, "pairIndex must be slot 1");
+        assertEq(uint256(vm.load(address(wl), keccak256(abi.encode(P_TO, inner)))), 1, "exactPairIndex must be slot 1");
         assertEq(
             uint256(vm.load(address(wl), keccak256(abi.encode(FW, uint256(3))))), 1, "fromWildcardIndex must be slot 3"
         );
@@ -502,30 +721,47 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
         assertEq(wl.layoutVersion(), 2);
     }
 
-    /// @notice op-reth filters canonical logs on this topic0. Both sides assert the same literal.
-    ///         The signature gained a third count in the pair rework, so this value changed — a
-    ///         sequencer built against the old one would never refresh, and would say nothing.
-    function test_whitelistUpdatedTopic0_isStable_succeeds() external pure {
+    /// @notice op-reth filters canonical logs on this topic0 (`WHITELIST_UPDATED_TOPIC0` in
+    ///         `mantle-reth/crates/preconf/src/whitelist.rs`); both sides pin the same literal. If
+    ///         the signature changes, the sequencer stops refreshing and says nothing about it — it
+    ///         keeps serving whatever list it read at bootstrap. That is the failure mode this
+    ///         assertion exists to prevent.
+    /// @dev    Read off the **emitted log**, deliberately, rather than hashing the signature as a
+    ///         string. A string-literal assertion is independent of the contract: changing the
+    ///         event and the test's local `WhitelistUpdated` declaration together — the natural way
+    ///         to refactor it — leaves such a test green while topic0 silently moves. Recording the
+    ///         log makes the literal answerable to what the contract actually emits.
+    function test_whitelistUpdatedTopic0_matchesTheEmittedLog_succeeds() external {
+        vm.recordLogs();
+        _gov(_one(address(0x5555), address(0x6666)), _none());
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(logs.length, 1, "exactly one event per update");
+        assertEq(logs[0].emitter, address(wl));
         assertEq(
-            keccak256("WhitelistUpdated(uint256,uint256,uint256)"),
-            0x532fe709f340eda40c9d51e7dbbacf9d5b255b36429ed90f865bd2a3131ef1bc
+            logs[0].topics[0],
+            0x532fe709f340eda40c9d51e7dbbacf9d5b255b36429ed90f865bd2a3131ef1bc,
+            "op-reth pins this same literal; both sides move together or neither does"
         );
     }
 
-    /// @notice The hardcoded messenger literal must equal the canonical predeploy constant.
-    function test_messengerAddress_matchesPredeploy_succeeds() external pure {
-        assertEq(Predeploys.L2_CROSS_DOMAIN_MESSENGER, 0x4200000000000000000000000000000000000007);
-    }
+    // ===== MAX_BATCH sizing =====
+    //
+    // `MAX_BATCH = 330` is not a round number picked for looks: it is calibrated so that a full
+    // batch of the most expensive rule form stays under the ~23M gas a governance message has to
+    // fit in. That justification lives entirely in the two measurements below, so they assert a
+    // ceiling rather than only logging. A change that inflates per-rule cost has to either stay
+    // under the bound or force whoever made it to re-derive `MAX_BATCH` — which is the point.
+    //
+    // The bounds are deliberately loose (about 2.5% of headroom over the recorded figures), so
+    // compiler-version noise does not turn them into a tripwire. Run with `-vv` to read the
+    // numbers; if a bound trips, re-measure and update the table in `PreconfWhitelist.sol`.
 
-    // ===== MAX_BATCH sizing (measurement, not an assertion) =====
-
-    /// @notice Measures a full `MAX_BATCH` of the most expensive rule form. `MAX_BATCH` exists to
-    ///         keep one relayed governance message inside its `minGasLimit` and inside the L2 block
-    ///         gas limit, so the number has to come from a measurement rather than an estimate.
-    ///         Run with `-vv` to read the numbers.
+    /// @notice A full `MAX_BATCH` of exact-pair adds — the expensive form `MAX_BATCH` is sized
+    ///         against. Recorded at 22,446,092 (68,018 per rule).
     function test_gas_maxBatchOfPairAdds() external {
         uint256 max = wl.MAX_BATCH();
-        PreconfWhitelist.Pair[] memory adds = _pairBatch(max, 0);
+        PreconfWhitelist.Rule[] memory adds = _pairBatch(max, 0);
         _asCrossDomain(AUTHORIZED_L1);
 
         uint256 g = gasleft();
@@ -535,13 +771,18 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
         console.log("MAX_BATCH             ", max);
         console.log("gas, all pair adds    ", used);
         console.log("gas per pair add      ", used / max);
+
+        assertLt(used, 23_000_000, "MAX_BATCH is calibrated against a ~23M ceiling -- re-derive it");
     }
 
     /// @notice The same batch made entirely of wildcards, to confirm the pair form really is the
-    ///         expensive one that `MAX_BATCH` should be sized against.
+    ///         expensive one. Recorded at 15,074,717 (45,680 per rule).
+    /// @dev    Bounded above by the pair figure as well as by an absolute number: if a wildcard add
+    ///         ever became the costlier of the two, `MAX_BATCH` would be sized against the wrong
+    ///         operation and the ceiling above would stop being an upper bound at all.
     function test_gas_maxBatchOfWildcardAdds() external {
         uint256 max = wl.MAX_BATCH();
-        PreconfWhitelist.Pair[] memory adds = new PreconfWhitelist.Pair[](max);
+        PreconfWhitelist.Rule[] memory adds = new PreconfWhitelist.Rule[](max);
         for (uint256 i = 0; i < max; i++) {
             adds[i] = _p(address(uint160(i + 1)), address(0));
         }
@@ -553,5 +794,8 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
 
         console.log("gas, all wildcard adds", used);
         console.log("gas per wildcard add  ", used / max);
+
+        assertLt(used, 15_500_000, "wildcard adds got more expensive -- re-measure");
+        assertLt(used, 22_446_092, "the exact-pair form must stay the expensive one");
     }
 }

--- a/packages/contracts-bedrock/test/PreconfWhitelist.t.sol
+++ b/packages/contracts-bedrock/test/PreconfWhitelist.t.sol
@@ -1,0 +1,557 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { console } from "forge-std/console.sol";
+import { Messenger_Initializer } from "./CommonTest.t.sol";
+import { CrossDomainMessenger } from "src/universal/CrossDomainMessenger.sol";
+import { Predeploys } from "src/libraries/Predeploys.sol";
+import { PreconfWhitelist } from "src/L2/PreconfWhitelist.sol";
+
+/// @title PreconfWhitelist_Test
+/// @notice Tests the three-form rule routing, the two-gate cross-domain authorization, the batch
+///         guard, and — critically — the storage layout and event topic that op-reth depends on.
+contract PreconfWhitelist_Test is Messenger_Initializer {
+    /// @notice The one L1 address allowed to govern the allowlist.
+    address internal constant AUTHORIZED_L1 = address(0xAbC0);
+
+    /// @notice Seeded exact rule.
+    address internal constant P_FROM = address(0x1111);
+    address internal constant P_TO = address(0x2222);
+    /// @notice Seeded sender wildcard.
+    address internal constant FW = address(0x3333);
+    /// @notice Seeded recipient wildcard.
+    address internal constant TW = address(0x4444);
+
+    PreconfWhitelist internal wl;
+
+    event WhitelistUpdated(uint256 pairCount, uint256 fromWildcardCount, uint256 toWildcardCount);
+
+    function setUp() public virtual override {
+        super.setUp();
+        // One of each form, so every test starts from a state that exercises all three sets.
+        PreconfWhitelist.Pair[] memory seed = new PreconfWhitelist.Pair[](3);
+        seed[0] = _p(P_FROM, P_TO);
+        seed[1] = _p(FW, address(0));
+        seed[2] = _p(address(0), TW);
+        wl = new PreconfWhitelist(AUTHORIZED_L1, seed);
+    }
+
+    // ===== helpers =====
+
+    function _p(address _from, address _to) internal pure returns (PreconfWhitelist.Pair memory) {
+        return PreconfWhitelist.Pair({ from: _from, to: _to });
+    }
+
+    /// @notice Single-element rule array.
+    function _one(address _from, address _to) internal pure returns (PreconfWhitelist.Pair[] memory out) {
+        out = new PreconfWhitelist.Pair[](1);
+        out[0] = _p(_from, _to);
+    }
+
+    /// @notice Empty rule array.
+    function _none() internal pure returns (PreconfWhitelist.Pair[] memory out) {
+        out = new PreconfWhitelist.Pair[](0);
+    }
+
+    /// @notice Makes the next call look like a relayed cross-domain message from `sender`.
+    function _asCrossDomain(address sender) internal {
+        vm.mockCall(
+            address(L2Messenger), abi.encodeCall(CrossDomainMessenger.xDomainMessageSender, ()), abi.encode(sender)
+        );
+        vm.prank(address(L2Messenger));
+    }
+
+    /// @notice `updatePreconfs` as the authorized L1 governor.
+    function _gov(PreconfWhitelist.Pair[] memory _add, PreconfWhitelist.Pair[] memory _remove) internal {
+        _asCrossDomain(AUTHORIZED_L1);
+        wl.updatePreconfs(_add, _remove);
+    }
+
+    /// @notice Reads the address stored `_off` slots past `_base`.
+    function _addrAt(bytes32 _base, uint256 _off) internal view returns (address) {
+        return address(uint160(uint256(vm.load(address(wl), bytes32(uint256(_base) + _off)))));
+    }
+
+    function _counts() internal view returns (uint256, uint256, uint256) {
+        return (wl.pairsLength(), wl.fromWildcardsLength(), wl.toWildcardsLength());
+    }
+
+    // ===== constructor / seeding =====
+
+    function test_constructor_seedsAllThreeForms_succeeds() external view {
+        assertEq(wl.AUTHORIZED_L1(), AUTHORIZED_L1);
+        assertTrue(wl.isWhitelistPair(P_FROM, P_TO));
+        assertTrue(wl.isFromWildcard(FW));
+        assertTrue(wl.isToWildcard(TW));
+        (uint256 p, uint256 f, uint256 t) = _counts();
+        assertEq(p, 1);
+        assertEq(f, 1);
+        assertEq(t, 1);
+    }
+
+    function test_constructor_emitsWhitelistUpdated_succeeds() external {
+        PreconfWhitelist.Pair[] memory seed = new PreconfWhitelist.Pair[](2);
+        seed[0] = _p(address(0xAA), address(0xBB));
+        seed[1] = _p(address(0xCC), address(0));
+
+        vm.expectEmit(true, true, true, true);
+        emit WhitelistUpdated(1, 1, 0);
+        new PreconfWhitelist(AUTHORIZED_L1, seed);
+    }
+
+    function test_constructor_zeroAuthorizedL1_reverts() external {
+        vm.expectRevert("PreconfWhitelist: authorized L1 sender is the zero address");
+        new PreconfWhitelist(address(0), _none());
+    }
+
+    /// @notice The all-zero form is rejected in the constructor too — `_apply` is the single place
+    ///         the three forms are interpreted, so both entry points agree by construction.
+    function test_constructor_allZeroPair_reverts() external {
+        vm.expectRevert("PreconfWhitelist: pair is all-zero");
+        new PreconfWhitelist(AUTHORIZED_L1, _one(address(0), address(0)));
+    }
+
+    // ===== routing: the three forms =====
+
+    /// @notice A rule with both halves set is an exact pair and touches neither wildcard set.
+    function test_updatePreconfs_exactPair_routesToPairs_succeeds() external {
+        _gov(_one(address(0x5555), address(0x6666)), _none());
+
+        assertTrue(wl.isWhitelistPair(address(0x5555), address(0x6666)));
+        assertFalse(wl.isWhitelistPair(address(0x6666), address(0x5555)), "direction matters");
+        assertFalse(wl.isFromWildcard(address(0x5555)));
+        assertFalse(wl.isToWildcard(address(0x6666)));
+        (uint256 p, uint256 f, uint256 t) = _counts();
+        assertEq(p, 2);
+        assertEq(f, 1);
+        assertEq(t, 1);
+    }
+
+    /// @notice `to == 0` means "everything from this sender".
+    function test_updatePreconfs_zeroTo_routesToFromWildcards_succeeds() external {
+        _gov(_one(address(0x5555), address(0)), _none());
+
+        assertTrue(wl.isFromWildcard(address(0x5555)));
+        assertFalse(wl.isToWildcard(address(0x5555)));
+        (uint256 p, uint256 f,) = _counts();
+        assertEq(p, 1, "must not create a pair");
+        assertEq(f, 2);
+    }
+
+    /// @notice `from == 0` means "everything to this recipient".
+    function test_updatePreconfs_zeroFrom_routesToToWildcards_succeeds() external {
+        _gov(_one(address(0), address(0x6666)), _none());
+
+        assertTrue(wl.isToWildcard(address(0x6666)));
+        assertFalse(wl.isFromWildcard(address(0x6666)));
+        (uint256 p,, uint256 t) = _counts();
+        assertEq(p, 1, "must not create a pair");
+        assertEq(t, 2);
+    }
+
+    /// @notice "All transactions are eligible" is the node operator's switch (`--preconf.all`), not
+    ///         governance's. Reverting also catches an uninitialized array element in a governance
+    ///         script, which would otherwise vanish silently.
+    function test_updatePreconfs_allZeroPair_reverts() external {
+        _asCrossDomain(AUTHORIZED_L1);
+        vm.expectRevert("PreconfWhitelist: pair is all-zero");
+        wl.updatePreconfs(_one(address(0), address(0)), _none());
+    }
+
+    /// @notice The all-zero check applies to removes as well, so a malformed revoke cannot be
+    ///         mistaken for a no-op.
+    function test_updatePreconfs_allZeroPairInRemove_reverts() external {
+        _asCrossDomain(AUTHORIZED_L1);
+        vm.expectRevert("PreconfWhitelist: pair is all-zero");
+        wl.updatePreconfs(_none(), _one(address(0), address(0)));
+    }
+
+    /// @notice No normalization across the sets: an exact pair and a covering wildcard coexist, and
+    ///         removing one leaves the other. This is the property that makes the OR in the
+    ///         sequencer's predicate honest — see the contract docs.
+    function test_pairAndWildcardCoexist_succeeds() external {
+        _gov(_one(FW, address(0x7777)), _none());
+        assertTrue(wl.isWhitelistPair(FW, address(0x7777)));
+        assertTrue(wl.isFromWildcard(FW));
+
+        // Revoking the exact rule does not revoke the wildcard that also covers it.
+        _gov(_none(), _one(FW, address(0x7777)));
+        assertFalse(wl.isWhitelistPair(FW, address(0x7777)));
+        assertTrue(wl.isFromWildcard(FW), "the wildcard still authorizes this traffic");
+    }
+
+    // ===== eligibility predicate =====
+
+    /// @notice Each of the three terms authorizes on its own. Seeded state has exactly one entry
+    ///         per set, and each case below matches through a different one.
+    function test_isWhitelist_anySingleTermAuthorizes_succeeds() external view {
+        assertTrue(wl.isWhitelist(P_FROM, P_TO), "exact pair");
+        assertTrue(wl.isWhitelist(FW, address(0x9999)), "sender wildcard, arbitrary recipient");
+        assertTrue(wl.isWhitelist(address(0x9999), TW), "recipient wildcard, arbitrary sender");
+    }
+
+    function test_isWhitelist_noTermMatches_returnsFalse() external view {
+        assertFalse(wl.isWhitelist(address(0x9999), address(0x8888)));
+    }
+
+    /// @notice The halves are not interchangeable: a sender wildcard does not authorize traffic
+    ///         *to* that address, and a recipient wildcard does not authorize traffic *from* it.
+    function test_isWhitelist_wildcardSidesAreNotSymmetric_returnsFalse() external view {
+        assertFalse(wl.isWhitelist(address(0x9999), FW), "FW is a sender wildcard, not a recipient one");
+        assertFalse(wl.isWhitelist(TW, address(0x9999)), "TW is a recipient wildcard, not a sender one");
+    }
+
+    /// @notice A contract creation is expressed as `_to == address(0)` and needs no special case:
+    ///         the zero address never reaches storage, so the pair and recipient terms are both
+    ///         false and the answer is exactly `isFromWildcard(_from)`. This is the property the
+    ///         sequencer's `Whitelist::is_eligible` reaches through an explicit `Option<Address>`.
+    function test_isWhitelist_creationFallsBackToFromWildcard_succeeds() external {
+        assertTrue(wl.isWhitelist(FW, address(0)), "sender wildcard authorizes a creation");
+        assertFalse(wl.isWhitelist(P_FROM, address(0)), "an exact rule does not authorize a creation");
+
+        // Revoking the wildcard removes the only term that could have authorized it.
+        _gov(_none(), _one(FW, address(0)));
+        assertFalse(wl.isWhitelist(FW, address(0)));
+    }
+
+    /// @notice No precedence and no deny list: revoking the exact pair leaves the traffic eligible
+    ///         while a wildcard still covers it. The wildcard has to be revoked too.
+    function test_isWhitelist_revokingPairLeavesWildcardCover_succeeds() external {
+        _gov(_one(FW, address(0x7777)), _none());
+        assertTrue(wl.isWhitelist(FW, address(0x7777)));
+
+        _gov(_none(), _one(FW, address(0x7777)));
+        assertFalse(wl.isWhitelistPair(FW, address(0x7777)), "the exact rule is gone");
+        assertTrue(wl.isWhitelist(FW, address(0x7777)), "but the sender wildcard still authorizes it");
+
+        _gov(_none(), _one(FW, address(0)));
+        assertFalse(wl.isWhitelist(FW, address(0x7777)), "only now is it revoked");
+    }
+
+    /// @notice The zero address is a calldata-only marker, so it is never a party in its own right:
+    ///         an all-zero query matches nothing even though every set is non-empty.
+    function test_isWhitelist_allZeroQuery_returnsFalse() external view {
+        assertFalse(wl.isWhitelist(address(0), address(0)));
+    }
+
+    // ===== add / remove semantics =====
+
+    function test_updatePreconfs_removeAcrossAllThreeSets_succeeds() external {
+        PreconfWhitelist.Pair[] memory rm = new PreconfWhitelist.Pair[](3);
+        rm[0] = _p(P_FROM, P_TO);
+        rm[1] = _p(FW, address(0));
+        rm[2] = _p(address(0), TW);
+        _gov(_none(), rm);
+
+        assertFalse(wl.isWhitelistPair(P_FROM, P_TO));
+        assertFalse(wl.isFromWildcard(FW));
+        assertFalse(wl.isToWildcard(TW));
+        (uint256 p, uint256 f, uint256 t) = _counts();
+        assertEq(p, 0);
+        assertEq(f, 0);
+        assertEq(t, 0);
+    }
+
+    function test_updatePreconfs_emitsWhitelistUpdated_succeeds() external {
+        vm.expectEmit(true, true, true, true, address(wl));
+        emit WhitelistUpdated(2, 1, 1);
+        _gov(_one(address(0x5555), address(0x6666)), _none());
+    }
+
+    /// @notice Adds are applied before removes, so a rule in both arguments ends up removed.
+    function test_updatePreconfs_addThenRemoveSamePair_succeeds() external {
+        _gov(_one(address(0x5555), address(0x6666)), _one(address(0x5555), address(0x6666)));
+        assertFalse(wl.isWhitelistPair(address(0x5555), address(0x6666)));
+    }
+
+    function test_updatePreconfs_addExisting_isNoop() external {
+        _gov(_one(P_FROM, P_TO), _none());
+        (uint256 p,,) = _counts();
+        assertEq(p, 1);
+        assertTrue(wl.isWhitelistPair(P_FROM, P_TO));
+    }
+
+    function test_updatePreconfs_removeAbsent_isNoop() external {
+        PreconfWhitelist.Pair[] memory rm = new PreconfWhitelist.Pair[](3);
+        rm[0] = _p(address(0xDEAD), address(0xBEEF));
+        rm[1] = _p(address(0xDEAD), address(0));
+        rm[2] = _p(address(0), address(0xBEEF));
+        _gov(_none(), rm);
+
+        (uint256 p, uint256 f, uint256 t) = _counts();
+        assertEq(p, 1);
+        assertEq(f, 1);
+        assertEq(t, 1);
+    }
+
+    /// @notice Swap-and-pop must keep `pairIndex` in step for the element that moved. Removing a
+    ///         *middle* element is the only case that exercises the swap; removing the last one
+    ///         takes a degenerate path where the element is swapped with itself.
+    function test_removePair_swapPop_keepsIndexInStep_succeeds() external {
+        PreconfWhitelist.Pair[] memory add = new PreconfWhitelist.Pair[](2);
+        add[0] = _p(address(0xA1), address(0xB1));
+        add[1] = _p(address(0xA2), address(0xB2));
+        _gov(add, _none()); // pairs = [seed, A1B1, A2B2]
+
+        _gov(_none(), _one(address(0xA1), address(0xB1))); // remove the middle one
+
+        (uint256 p,,) = _counts();
+        assertEq(p, 2);
+        assertFalse(wl.isWhitelistPair(address(0xA1), address(0xB1)));
+        assertTrue(wl.isWhitelistPair(address(0xA2), address(0xB2)), "the moved element stays indexed");
+        // And its recorded position must be the one it actually occupies now.
+        assertEq(wl.pairIndex(address(0xA2), address(0xB2)), 2);
+        (address f, address t) = wl.pairs(1);
+        assertEq(f, address(0xA2));
+        assertEq(t, address(0xB2));
+    }
+
+    /// @notice Removing the final element: the swap writes it over itself, so the subsequent
+    ///         `delete` is what actually clears the index. A guard against "restore then forget".
+    function test_removePair_lastElement_succeeds() external {
+        _gov(_one(address(0xA1), address(0xB1)), _none());
+        _gov(_none(), _one(address(0xA1), address(0xB1)));
+
+        (uint256 p,,) = _counts();
+        assertEq(p, 1);
+        assertFalse(wl.isWhitelistPair(address(0xA1), address(0xB1)));
+        assertEq(wl.pairIndex(address(0xA1), address(0xB1)), 0);
+    }
+
+    // ===== authorization: design doc §5.2 attacks B and C =====
+
+    /// @notice Attack B — deposit aimed straight at this contract, bypassing the messenger.
+    function test_updatePreconfs_notMessenger_reverts() external {
+        vm.prank(alice);
+        vm.expectRevert("PreconfWhitelist: caller is not the messenger");
+        wl.updatePreconfs(_one(address(0x9999), address(0x8888)), _none());
+        assertFalse(wl.isWhitelistPair(address(0x9999), address(0x8888)));
+    }
+
+    /// @notice Attack C — a legitimate but unauthorized L1 caller relaying through the messenger.
+    function test_updatePreconfs_unauthorizedL1Sender_reverts() external {
+        _asCrossDomain(alice);
+        vm.expectRevert("PreconfWhitelist: caller is not the authorized L1 sender");
+        wl.updatePreconfs(_one(address(0x9999), address(0x8888)), _none());
+        assertFalse(wl.isWhitelistPair(address(0x9999), address(0x8888)));
+    }
+
+    /// @notice The messenger address itself is not privileged — reaching us with a zero
+    ///         `xDomainMessageSender` (i.e. not mid-relay) must still fail gate 2.
+    function test_updatePreconfs_zeroXDomainSender_reverts() external {
+        _asCrossDomain(address(0));
+        vm.expectRevert("PreconfWhitelist: caller is not the authorized L1 sender");
+        wl.updatePreconfs(_one(address(0x9999), address(0x8888)), _none());
+    }
+
+    // ===== batch guard =====
+
+    /// @notice Builds `_n` distinct exact pairs — the most expensive rule form, which is what
+    ///         `MAX_BATCH` is sized against.
+    function _pairBatch(uint256 _n, uint256 _seed) internal pure returns (PreconfWhitelist.Pair[] memory out) {
+        out = new PreconfWhitelist.Pair[](_n);
+        for (uint256 i = 0; i < _n; i++) {
+            out[i] = PreconfWhitelist.Pair({
+                from: address(uint160(_seed + i + 1)),
+                to: address(uint160(_seed + i + 0x100000))
+            });
+        }
+    }
+
+    function test_updatePreconfs_atMaxBatch_succeeds() external {
+        uint256 max = wl.MAX_BATCH();
+        _gov(_pairBatch(max, 0), _none());
+        (uint256 p,,) = _counts();
+        assertEq(p, max + 1, "on top of the seeded pair");
+    }
+
+    /// @notice Also asserts that nothing changed: the guard reverts before any SSTORE, so a
+    ///         rejected governance message is cheap and leaves no partial application behind.
+    /// @dev    The batch is built *before* `_asCrossDomain`, deliberately. `wl.MAX_BATCH()` is an
+    ///         external call; evaluated inside the argument list it would consume the `vm.prank`
+    ///         and the `vm.expectRevert`, leaving the test to assert against the wrong call. That
+    ///         mistake passes as a green test, so it is worth the extra line.
+    function test_updatePreconfs_overMaxBatch_revertsAndChangesNothing() external {
+        PreconfWhitelist.Pair[] memory over = _pairBatch(wl.MAX_BATCH() + 1, 0);
+
+        _asCrossDomain(AUTHORIZED_L1);
+        vm.expectRevert("PreconfWhitelist: batch too large");
+        wl.updatePreconfs(over, _none());
+
+        (uint256 p, uint256 f, uint256 t) = _counts();
+        assertEq(p, 1);
+        assertEq(f, 1);
+        assertEq(t, 1);
+    }
+
+    /// @notice The cap is on the SUM across both arguments, not per-array.
+    function test_updatePreconfs_sumAcrossArgsExceedsMax_reverts() external {
+        uint256 max = wl.MAX_BATCH();
+        _asCrossDomain(AUTHORIZED_L1);
+        vm.expectRevert("PreconfWhitelist: batch too large");
+        wl.updatePreconfs(_pairBatch(max / 2 + 1, 0), _pairBatch(max / 2 + 1, 0x1000000));
+    }
+
+    // ===== pagination =====
+
+    function test_getPairs_paging_succeeds() external {
+        _gov(_pairBatch(4, 0), _none()); // 5 total, including the seed
+
+        assertEq(wl.pairsLength(), 5);
+        assertEq(wl.getPairs(0, 2).length, 2, "a full page");
+        assertEq(wl.getPairs(4, 10).length, 1, "an over-long limit truncates to the end");
+        assertEq(wl.getPairs(5, 10).length, 0, "offset == length is empty, not a revert");
+        assertEq(wl.getPairs(99, 10).length, 0, "offset past the end is empty, not a revert");
+        assertEq(wl.getPairs(0, type(uint256).max).length, 5, "the limit must not overflow");
+    }
+
+    /// @notice The page contents must line up with the underlying indices, or a caller walking the
+    ///         list would silently skip or repeat rules.
+    function test_getPairs_pageContents_succeeds() external {
+        _gov(_pairBatch(4, 0), _none());
+
+        PreconfWhitelist.Pair[] memory page = wl.getPairs(1, 2);
+        (address f1, address t1) = wl.pairs(1);
+        (address f2, address t2) = wl.pairs(2);
+        assertEq(page[0].from, f1);
+        assertEq(page[0].to, t1);
+        assertEq(page[1].from, f2);
+        assertEq(page[1].to, t2);
+    }
+
+    function test_getWildcards_paging_succeeds() external {
+        PreconfWhitelist.Pair[] memory add = new PreconfWhitelist.Pair[](4);
+        add[0] = _p(address(0xF1), address(0));
+        add[1] = _p(address(0xF2), address(0));
+        add[2] = _p(address(0), address(0xD1));
+        add[3] = _p(address(0), address(0xD2));
+        _gov(add, _none());
+
+        assertEq(wl.getFromWildcards(0, 10).length, 3, "over-long limit truncates");
+        assertEq(wl.getFromWildcards(3, 1).length, 0, "offset == length is empty");
+        assertEq(wl.getToWildcards(1, 1).length, 1);
+        assertEq(wl.getToWildcards(0, type(uint256).max).length, 3, "the limit must not overflow");
+    }
+
+    // ===== op-reth coupling: storage layout + event topic =====
+
+    /// @notice op-reth reads these slots directly. If this test fails, the Rust constants in
+    ///         `mantle-reth/crates/preconf/src/whitelist.rs` must change in lockstep.
+    ///
+    ///         The `pairs` assertions also pin the **two-slot element stride**, which is the whole
+    ///         basis of the Rust reader's `base + 2i` / `base + 2i + 1` addressing. Two addresses
+    ///         are 40 bytes and cannot share a slot; this proves the compiler agrees at runtime,
+    ///         rather than leaving it to a reading of the layout rules.
+    function test_storageLayout_matchesRethExpectations_succeeds() external {
+        _gov(_one(address(0xA9), address(0xB9)), _none()); // a second pair, so the stride shows
+
+        // Array lengths live at the declaring slot.
+        assertEq(uint256(vm.load(address(wl), bytes32(uint256(0)))), 2, "pairs must be slot 0");
+        assertEq(uint256(vm.load(address(wl), bytes32(uint256(2)))), 1, "fromWildcards must be slot 2");
+        assertEq(uint256(vm.load(address(wl), bytes32(uint256(4)))), 1, "toWildcards must be slot 4");
+
+        bytes32 pairsBase = keccak256(abi.encode(uint256(0)));
+        assertEq(_addrAt(pairsBase, 0), P_FROM, "pairs[0].from at base+0");
+        assertEq(_addrAt(pairsBase, 1), P_TO, "pairs[0].to at base+1");
+        assertEq(_addrAt(pairsBase, 2), address(0xA9), "pairs[1].from at base+2 -- the 2-slot stride");
+        assertEq(_addrAt(pairsBase, 3), address(0xB9), "pairs[1].to at base+3");
+
+        assertEq(_addrAt(keccak256(abi.encode(uint256(2))), 0), FW, "fromWildcards[0]");
+        assertEq(_addrAt(keccak256(abi.encode(uint256(4))), 0), TW, "toWildcards[0]");
+    }
+
+    /// @notice The three index mappings sit immediately after their arrays, at slots 1, 3 and 5.
+    ///         This pins the whole 0..5 block so an inserted variable cannot slide the arrays
+    ///         unnoticed. `pairIndex` is nested, so its slot is a double hash.
+    function test_storageLayout_indexMappingSlots_succeeds() external view {
+        bytes32 inner = keccak256(abi.encode(P_FROM, uint256(1)));
+        assertEq(uint256(vm.load(address(wl), keccak256(abi.encode(P_TO, inner)))), 1, "pairIndex must be slot 1");
+        assertEq(
+            uint256(vm.load(address(wl), keccak256(abi.encode(FW, uint256(3))))), 1, "fromWildcardIndex must be slot 3"
+        );
+        assertEq(
+            uint256(vm.load(address(wl), keccak256(abi.encode(TW, uint256(5))))), 1, "toWildcardIndex must be slot 5"
+        );
+    }
+
+    /// @notice The layout marker op-reth checks at cold start. It has to be **after** every array,
+    ///         or bumping it would shift the very slots it is meant to protect — so the slot number
+    ///         is asserted, not just the value.
+    ///
+    ///         The previous cross-product contract never wrote this slot, so it reads back as `0`
+    ///         there. That is what lets a sequencer built for this layout refuse to start against
+    ///         it, instead of reading its recipient list out of slot 2 and installing it as sender
+    ///         wildcards.
+    function test_storageLayout_layoutVersion_succeeds() external view {
+        assertEq(uint256(vm.load(address(wl), bytes32(uint256(6)))), 2, "layoutVersion must be slot 6");
+        assertEq(wl.layoutVersion(), wl.LAYOUT_VERSION());
+        assertEq(wl.LAYOUT_VERSION(), 2);
+    }
+
+    /// @notice The marker is written by the constructor, so every deployment carries it — there is
+    ///         no window in which a live contract reads back as version 0.
+    function test_constructor_writesLayoutVersion_succeeds() external {
+        PreconfWhitelist fresh = new PreconfWhitelist(AUTHORIZED_L1, _none());
+        assertEq(fresh.layoutVersion(), 2, "even an empty deployment declares its layout");
+    }
+
+    /// @notice `updatePreconfs` must never touch it: it describes the shape of storage, not its
+    ///         contents, and governance has no say over the shape.
+    function test_updatePreconfs_leavesLayoutVersionAlone_succeeds() external {
+        _gov(_one(address(0x5555), address(0x6666)), _one(P_FROM, P_TO));
+        assertEq(wl.layoutVersion(), 2);
+    }
+
+    /// @notice op-reth filters canonical logs on this topic0. Both sides assert the same literal.
+    ///         The signature gained a third count in the pair rework, so this value changed — a
+    ///         sequencer built against the old one would never refresh, and would say nothing.
+    function test_whitelistUpdatedTopic0_isStable_succeeds() external pure {
+        assertEq(
+            keccak256("WhitelistUpdated(uint256,uint256,uint256)"),
+            0x532fe709f340eda40c9d51e7dbbacf9d5b255b36429ed90f865bd2a3131ef1bc
+        );
+    }
+
+    /// @notice The hardcoded messenger literal must equal the canonical predeploy constant.
+    function test_messengerAddress_matchesPredeploy_succeeds() external pure {
+        assertEq(Predeploys.L2_CROSS_DOMAIN_MESSENGER, 0x4200000000000000000000000000000000000007);
+    }
+
+    // ===== MAX_BATCH sizing (measurement, not an assertion) =====
+
+    /// @notice Measures a full `MAX_BATCH` of the most expensive rule form. `MAX_BATCH` exists to
+    ///         keep one relayed governance message inside its `minGasLimit` and inside the L2 block
+    ///         gas limit, so the number has to come from a measurement rather than an estimate.
+    ///         Run with `-vv` to read the numbers.
+    function test_gas_maxBatchOfPairAdds() external {
+        uint256 max = wl.MAX_BATCH();
+        PreconfWhitelist.Pair[] memory adds = _pairBatch(max, 0);
+        _asCrossDomain(AUTHORIZED_L1);
+
+        uint256 g = gasleft();
+        wl.updatePreconfs(adds, _none());
+        uint256 used = g - gasleft();
+
+        console.log("MAX_BATCH             ", max);
+        console.log("gas, all pair adds    ", used);
+        console.log("gas per pair add      ", used / max);
+    }
+
+    /// @notice The same batch made entirely of wildcards, to confirm the pair form really is the
+    ///         expensive one that `MAX_BATCH` should be sized against.
+    function test_gas_maxBatchOfWildcardAdds() external {
+        uint256 max = wl.MAX_BATCH();
+        PreconfWhitelist.Pair[] memory adds = new PreconfWhitelist.Pair[](max);
+        for (uint256 i = 0; i < max; i++) {
+            adds[i] = _p(address(uint160(i + 1)), address(0));
+        }
+        _asCrossDomain(AUTHORIZED_L1);
+
+        uint256 g = gasleft();
+        wl.updatePreconfs(adds, _none());
+        uint256 used = g - gasleft();
+
+        console.log("gas, all wildcard adds", used);
+        console.log("gas per wildcard add  ", used / max);
+    }
+}

--- a/packages/contracts-bedrock/test/PreconfWhitelist.t.sol
+++ b/packages/contracts-bedrock/test/PreconfWhitelist.t.sol
@@ -61,10 +61,15 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
         vm.prank(address(L2Messenger));
     }
 
-    /// @notice `updatePreconfs` as the authorized L1 governor.
+    /// @notice Monotonic governance nonce handed out by `_gov`, so tests that do not care about
+    ///         replay protection never have to think about it. Tests that *do* care call
+    ///         `updatePreconfs` directly with an explicit nonce.
+    uint256 internal govNonce;
+
+    /// @notice `updatePreconfs` as the authorized L1 governor, on the next nonce.
     function _gov(PreconfWhitelist.Rule[] memory _add, PreconfWhitelist.Rule[] memory _remove) internal {
         _asCrossDomain(AUTHORIZED_L1);
-        wl.updatePreconfs(_add, _remove);
+        wl.updatePreconfs(++govNonce, _add, _remove);
     }
 
     /// @notice Reads the address stored `_off` slots past `_base`.
@@ -173,7 +178,7 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
     function test_updatePreconfs_allZeroPair_reverts() external {
         _asCrossDomain(AUTHORIZED_L1);
         vm.expectRevert("PreconfWhitelist: pair is all-zero");
-        wl.updatePreconfs(_one(address(0), address(0)), _none());
+        wl.updatePreconfs(++govNonce, _one(address(0), address(0)), _none());
     }
 
     /// @notice The all-zero check applies to removes as well, so a malformed revoke cannot be
@@ -181,7 +186,7 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
     function test_updatePreconfs_allZeroPairInRemove_reverts() external {
         _asCrossDomain(AUTHORIZED_L1);
         vm.expectRevert("PreconfWhitelist: pair is all-zero");
-        wl.updatePreconfs(_none(), _one(address(0), address(0)));
+        wl.updatePreconfs(++govNonce, _none(), _one(address(0), address(0)));
     }
 
     /// @notice No normalization across the sets: an exact pair and a covering wildcard coexist, and
@@ -349,14 +354,14 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
     function test_updatePreconfs_notMessenger_reverts() external {
         vm.prank(alice);
         vm.expectRevert("PreconfWhitelist: caller is not the messenger");
-        wl.updatePreconfs(_one(address(0x9999), address(0x8888)), _none());
+        wl.updatePreconfs(++govNonce, _one(address(0x9999), address(0x8888)), _none());
     }
 
     /// @notice Attack C — a legitimate but unauthorized L1 caller relaying through the messenger.
     function test_updatePreconfs_unauthorizedL1Sender_reverts() external {
         _asCrossDomain(alice);
         vm.expectRevert("PreconfWhitelist: caller is not the authorized L1 sender");
-        wl.updatePreconfs(_one(address(0x9999), address(0x8888)), _none());
+        wl.updatePreconfs(++govNonce, _one(address(0x9999), address(0x8888)), _none());
     }
 
     /// @notice The messenger address itself is not privileged — reaching us with a zero
@@ -364,7 +369,130 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
     function test_updatePreconfs_zeroXDomainSender_reverts() external {
         _asCrossDomain(address(0));
         vm.expectRevert("PreconfWhitelist: caller is not the authorized L1 sender");
-        wl.updatePreconfs(_one(address(0x9999), address(0x8888)), _none());
+        wl.updatePreconfs(++govNonce, _one(address(0x9999), address(0x8888)), _none());
+    }
+
+    // ===== replay guard: the governance nonce =====
+    //
+    // A relayed message that fails lands in the messenger's `failedMessages` mapping, from where
+    // anyone may replay it forever. The nonce is what stops a months-old delta from being applied
+    // at a moment of the replayer's choosing. See `localNonce`'s docs for what it does not cover.
+
+    /// @notice The counter starts at zero, so the first accepted message must carry at least 1.
+    function test_updatePreconfs_nonceStartsAtZero_succeeds() external {
+        assertEq(wl.localNonce(), 0, "a fresh deployment has consumed no nonce");
+
+        _asCrossDomain(AUTHORIZED_L1);
+        wl.updatePreconfs(1, _one(address(0x5555), address(0x6666)), _none());
+        assertEq(wl.localNonce(), 1);
+    }
+
+    /// @notice The guard is strict: re-sending the nonce that was just consumed is refused. This is
+    ///         the case that matters, because it is exactly what a replay of the most recent
+    ///         message looks like from this contract's side.
+    function test_updatePreconfs_replayingTheConsumedNonce_reverts() external {
+        _asCrossDomain(AUTHORIZED_L1);
+        wl.updatePreconfs(5, _one(address(0xA1), address(0xB1)), _none());
+
+        _asCrossDomain(AUTHORIZED_L1);
+        vm.expectRevert("PreconfWhitelist: stale nonce");
+        wl.updatePreconfs(5, _one(address(0xA2), address(0xB2)), _none());
+    }
+
+    /// @notice The scenario the guard exists for: a stale delta replayed after a newer message
+    ///         moved the allowlist on. Without the nonce this would silently re-authorize traffic
+    ///         governance had revoked, at a moment the replayer picks.
+    function test_updatePreconfs_staleDeltaAfterNewerMessage_revertsAndChangesNothing() external {
+        // Governance authorizes A1 -> B1 at nonce 7 ...
+        _asCrossDomain(AUTHORIZED_L1);
+        wl.updatePreconfs(7, _one(address(0xA1), address(0xB1)), _none());
+        assertTrue(wl.isExactPair(address(0xA1), address(0xB1)));
+
+        // ... then revokes it at nonce 8.
+        _asCrossDomain(AUTHORIZED_L1);
+        wl.updatePreconfs(8, _none(), _one(address(0xA1), address(0xB1)));
+        assertFalse(wl.isExactPair(address(0xA1), address(0xB1)));
+
+        // Replaying the nonce-7 message would re-authorize it. It must not.
+        _asCrossDomain(AUTHORIZED_L1);
+        vm.expectRevert("PreconfWhitelist: stale nonce");
+        wl.updatePreconfs(7, _one(address(0xA1), address(0xB1)), _none());
+
+        assertFalse(wl.isExactPair(address(0xA1), address(0xB1)), "the revocation stands");
+        assertEq(wl.localNonce(), 8, "a refused message consumes nothing");
+    }
+
+    /// @notice Gaps are allowed — the nonce only has to increase. Governance may therefore source
+    ///         it from `L1CrossDomainMessenger.messageNonce()`, which counts all bridge traffic and
+    ///         so advances in large jumps between two governance messages.
+    function test_updatePreconfs_nonceMayJump_succeeds() external {
+        _asCrossDomain(AUTHORIZED_L1);
+        wl.updatePreconfs(1, _one(address(0xA1), address(0xB1)), _none());
+
+        _asCrossDomain(AUTHORIZED_L1);
+        wl.updatePreconfs(9_000_000, _one(address(0xA2), address(0xB2)), _none());
+
+        assertEq(wl.localNonce(), 9_000_000);
+        assertTrue(wl.isExactPair(address(0xA2), address(0xB2)));
+    }
+
+    /// @notice A legitimate retry after a failure still works. The failed message never reached
+    ///         this contract's body, so it consumed no nonce — replaying it finds the counter
+    ///         exactly where it left it. Losing this would make the guard worse than the problem,
+    ///         since out-of-gas is the one failure a replay is *supposed* to fix.
+    /// @dev    The failure is modelled with the batch guard rather than a real OOG: both leave the
+    ///         counter untouched, and the batch guard is deterministic enough to assert on.
+    function test_updatePreconfs_retryAfterFailureKeepsItsNonce_succeeds() external {
+        _asCrossDomain(AUTHORIZED_L1);
+        wl.updatePreconfs(3, _one(address(0xA1), address(0xB1)), _none());
+
+        PreconfWhitelist.Rule[] memory over = _pairBatch(wl.MAX_BATCH() + 1, 0);
+        _asCrossDomain(AUTHORIZED_L1);
+        vm.expectRevert("PreconfWhitelist: batch too large");
+        wl.updatePreconfs(4, over, _none());
+        assertEq(wl.localNonce(), 3, "a failed message consumes no nonce");
+
+        // The corrected message reuses nonce 4 and lands.
+        _asCrossDomain(AUTHORIZED_L1);
+        wl.updatePreconfs(4, _one(address(0xA2), address(0xB2)), _none());
+        assertEq(wl.localNonce(), 4);
+        assertTrue(wl.isExactPair(address(0xA2), address(0xB2)));
+    }
+
+    /// @notice The documented remedy for "governance failed, then reconsidered and sent nothing
+    ///         more": an empty update whose only job is to burn the nonce. Two empty arrays are
+    ///         valid input and cost almost nothing, so this message cannot itself run out of gas —
+    ///         which is what makes it a reliable way to close the replay window.
+    function test_updatePreconfs_emptyUpdateBurnsTheNonce_succeeds() external {
+        _asCrossDomain(AUTHORIZED_L1);
+        wl.updatePreconfs(10, _one(address(0xA1), address(0xB1)), _none());
+        (uint256 p, uint256 f, uint256 t) = _counts();
+
+        // Say nonce 11 failed and will never be re-sent. Burn it.
+        _asCrossDomain(AUTHORIZED_L1);
+        wl.updatePreconfs(12, _none(), _none());
+        assertEq(wl.localNonce(), 12, "the window for 11 is now closed");
+
+        (uint256 p2, uint256 f2, uint256 t2) = _counts();
+        assertEq(p2, p, "an empty update changes no rule");
+        assertEq(f2, f);
+        assertEq(t2, t);
+
+        _asCrossDomain(AUTHORIZED_L1);
+        vm.expectRevert("PreconfWhitelist: stale nonce");
+        wl.updatePreconfs(11, _one(address(0xBAD), address(0xBAD)), _none());
+    }
+
+    /// @notice The nonce guard runs before the batch guard. Both would reject an oversized *and*
+    ///         stale message; asserting the order pins which error the caller is shown.
+    function test_updatePreconfs_nonceGuardPrecedesBatchGuard_reverts() external {
+        _asCrossDomain(AUTHORIZED_L1);
+        wl.updatePreconfs(20, _none(), _none());
+
+        PreconfWhitelist.Rule[] memory over = _pairBatch(wl.MAX_BATCH() + 1, 0);
+        _asCrossDomain(AUTHORIZED_L1);
+        vm.expectRevert("PreconfWhitelist: stale nonce");
+        wl.updatePreconfs(20, over, _none());
     }
 
     // ===== batch guard =====
@@ -399,7 +527,7 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
 
         _asCrossDomain(AUTHORIZED_L1);
         vm.expectRevert("PreconfWhitelist: batch too large");
-        wl.updatePreconfs(over, _none());
+        wl.updatePreconfs(++govNonce, over, _none());
 
         (uint256 p, uint256 f, uint256 t) = _counts();
         assertEq(p, 1);
@@ -412,7 +540,7 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
         uint256 max = wl.MAX_BATCH();
         _asCrossDomain(AUTHORIZED_L1);
         vm.expectRevert("PreconfWhitelist: batch too large");
-        wl.updatePreconfs(_pairBatch(max / 2 + 1, 0), _pairBatch(max / 2 + 1, 0x1000000));
+        wl.updatePreconfs(++govNonce, _pairBatch(max / 2 + 1, 0), _pairBatch(max / 2 + 1, 0x1000000));
     }
 
     // ===== pagination =====
@@ -707,6 +835,21 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
         assertEq(wl.LAYOUT_VERSION(), 2);
     }
 
+    /// @notice `localNonce` is appended *after* `layoutVersion`, so adding it moved none of the
+    ///         slots op-reth reads — which is why it did not bump `LAYOUT_VERSION`. Asserting the
+    ///         slot number is the guard: an accidental insertion higher up would slide `layoutVersion`
+    ///         off slot 6 and every array with it, and the Rust side would read garbage while still
+    ///         seeing the version it expects.
+    function test_storageLayout_localNonceIsAppendedAtSlot7_succeeds() external {
+        _asCrossDomain(AUTHORIZED_L1);
+        wl.updatePreconfs(42, _none(), _none());
+
+        assertEq(uint256(vm.load(address(wl), bytes32(uint256(7)))), 42, "localNonce must be slot 7");
+        assertEq(wl.localNonce(), 42);
+        assertEq(uint256(vm.load(address(wl), bytes32(uint256(6)))), 2, "layoutVersion still slot 6");
+        assertEq(wl.LAYOUT_VERSION(), 2, "appending a variable is not a layout change");
+    }
+
     /// @notice The marker is written by the constructor, so every deployment carries it — there is
     ///         no window in which a live contract reads back as version 0.
     function test_constructor_writesLayoutVersion_succeeds() external {
@@ -751,37 +894,37 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
     // the gas a governance message can actually be given. That budget comes from **L1**, not from
     // the L2 block: `OptimismPortal.depositTransaction` is `metered`, so `ResourceMetering` caps the
     // deposit gas bought per L1 block at `maxResourceLimit` (20,000,000), and
-    // `CrossDomainMessenger.baseGas` spends 683,088 of it on overhead before the EIP-150 63/64 term
-    // — leaving 19,015,085 of `_minGasLimit`. The full derivation is on `MAX_BATCH` in
-    // `PreconfWhitelist.sol`; extrapolating the two figures below puts the hard ceiling near 276.
+    // `CrossDomainMessenger.baseGas` spends 683,664 of it on overhead before the EIP-150 63/64 term
+    // — leaving 19,014,519 of `_minGasLimit`. The full derivation is on `MAX_BATCH` in
+    // `PreconfWhitelist.sol`; extrapolating the figures below puts the hard ceiling at 275.
     //
     // That justification lives entirely in the two measurements below, so they assert the ceiling
     // rather than only logging. A change that inflates per-rule cost has to either stay under the
     // bound or force whoever made it to re-derive `MAX_BATCH` — which is the point. The pair bound
-    // is the real 19,015,085 figure, which sits 7% above the recorded cost, so compiler-version
+    // is the real 19,014,519 figure, which sits 6.7% above the recorded cost, so compiler-version
     // noise is not a tripwire. Run with `-vv` to read the numbers; if a bound trips, re-measure and
     // update the table in `PreconfWhitelist.sol`.
 
     /// @notice A full `MAX_BATCH` of exact-pair adds — the expensive form `MAX_BATCH` is sized
-    ///         against. Recorded at 17,689,309 (69,098 per rule).
+    ///         against. Recorded at 17,734,481 (69,275 per rule).
     function test_gas_maxBatchOfPairAdds() external {
         uint256 max = wl.MAX_BATCH();
         PreconfWhitelist.Rule[] memory adds = _pairBatch(max, 0);
         _asCrossDomain(AUTHORIZED_L1);
 
         uint256 g = gasleft();
-        wl.updatePreconfs(adds, _none());
+        wl.updatePreconfs(++govNonce, adds, _none());
         uint256 used = g - gasleft();
 
         console.log("MAX_BATCH             ", max);
         console.log("gas, all pair adds    ", used);
         console.log("gas per pair add      ", used / max);
 
-        assertLt(used, 19_015_085, "a full batch must fit in the _minGasLimit L1 can pay for -- re-derive MAX_BATCH");
+        assertLt(used, 19_014_519, "a full batch must fit in the _minGasLimit L1 can pay for -- re-derive MAX_BATCH");
     }
 
     /// @notice The same batch made entirely of wildcards, to confirm the pair form really is the
-    ///         expensive one. Recorded at 11,941,833 (46,647 per rule).
+    ///         expensive one. Recorded at 11,987,007 (46,824 per rule).
     /// @dev    Bounded above by the pair figure as well as by an absolute number: if a wildcard add
     ///         ever became the costlier of the two, `MAX_BATCH` would be sized against the wrong
     ///         operation and the ceiling above would stop being an upper bound at all.
@@ -794,13 +937,13 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
         _asCrossDomain(AUTHORIZED_L1);
 
         uint256 g = gasleft();
-        wl.updatePreconfs(adds, _none());
+        wl.updatePreconfs(++govNonce, adds, _none());
         uint256 used = g - gasleft();
 
         console.log("gas, all wildcard adds", used);
         console.log("gas per wildcard add  ", used / max);
 
-        assertLt(used, 12_300_000, "wildcard adds got more expensive -- re-measure");
-        assertLt(used, 17_689_309, "the exact-pair form must stay the expensive one");
+        assertLt(used, 12_400_000, "wildcard adds got more expensive -- re-measure");
+        assertLt(used, 17_734_481, "the exact-pair form must stay the expensive one");
     }
 }

--- a/packages/contracts-bedrock/test/PreconfWhitelist.t.sol
+++ b/packages/contracts-bedrock/test/PreconfWhitelist.t.sol
@@ -3,14 +3,15 @@ pragma solidity 0.8.15;
 
 import { console } from "forge-std/console.sol";
 import { Vm } from "forge-std/Vm.sol";
-import { Messenger_Initializer } from "./CommonTest.t.sol";
-import { CrossDomainMessenger } from "src/universal/CrossDomainMessenger.sol";
+import { Portal_Initializer } from "./CommonTest.t.sol";
+import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
+import { Predeploys } from "src/libraries/Predeploys.sol";
 import { PreconfWhitelist } from "src/L2/PreconfWhitelist.sol";
 
 /// @title PreconfWhitelist_Test
-/// @notice Tests the three-form rule routing, the two-gate cross-domain authorization, the batch
-///         guard, and — critically — the storage layout and event topic that op-reth depends on.
-contract PreconfWhitelist_Test is Messenger_Initializer {
+/// @notice Tests the three-form rule routing, the alias-based authorization gate, the batch guard,
+///         and — critically — the storage layout and event topic that op-reth depends on.
+contract PreconfWhitelist_Test is Portal_Initializer {
     /// @notice The one L1 address allowed to govern the allowlist.
     address internal constant AUTHORIZED_L1 = address(0xAbC0);
 
@@ -25,6 +26,7 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
     PreconfWhitelist internal wl;
 
     event WhitelistUpdated(uint256 exactPairCount, uint256 fromWildcardCount, uint256 toWildcardCount);
+    event AuthorizedL1Updated(address indexed previousAuthorizedL1, address indexed newAuthorizedL1);
 
     function setUp() public virtual override {
         super.setUp();
@@ -53,23 +55,19 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
         out_ = new PreconfWhitelist.Rule[](0);
     }
 
-    /// @notice Makes the next call look like a relayed cross-domain message from `sender`.
-    function _asCrossDomain(address sender) internal {
-        vm.mockCall(
-            address(L2Messenger), abi.encodeCall(CrossDomainMessenger.xDomainMessageSender, ()), abi.encode(sender)
-        );
-        vm.prank(address(L2Messenger));
+    /// @notice Makes the next call look like a deposit that `_l1Sender` originated on L1.
+    /// @dev    Pranks the **aliased** address, because that is what `msg.sender` actually is here:
+    ///         `OptimismPortal.depositTransaction` applies the alias to every contract depositor,
+    ///         and governance is a contract. Pranking the raw `_l1Sender` would exercise a gate
+    ///         this contract deliberately does not have — see `test_updatePreconfs_unaliasedAuthorizedL1_reverts`.
+    function _asL1(address _l1Sender) internal {
+        vm.prank(AddressAliasHelper.applyL1ToL2Alias(_l1Sender));
     }
 
-    /// @notice Monotonic governance nonce handed out by `_gov`, so tests that do not care about
-    ///         replay protection never have to think about it. Tests that *do* care call
-    ///         `updatePreconfs` directly with an explicit nonce.
-    uint256 internal govNonce;
-
-    /// @notice `updatePreconfs` as the authorized L1 governor, on the next nonce.
+    /// @notice `updatePreconfs` as the authorized L1 governor.
     function _gov(PreconfWhitelist.Rule[] memory _add, PreconfWhitelist.Rule[] memory _remove) internal {
-        _asCrossDomain(AUTHORIZED_L1);
-        wl.updatePreconfs(++govNonce, _add, _remove);
+        _asL1(AUTHORIZED_L1);
+        wl.updatePreconfs(_add, _remove);
     }
 
     /// @notice Reads the address stored `_off` slots past `_base`.
@@ -102,7 +100,7 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
     // ===== constructor / seeding =====
 
     function test_constructor_seedsAllThreeForms_succeeds() external view {
-        assertEq(wl.AUTHORIZED_L1(), AUTHORIZED_L1);
+        assertEq(wl.authorizedL1(), AUTHORIZED_L1);
         assertTrue(wl.isExactPair(P_FROM, P_TO));
         assertTrue(wl.isFromWildcard(FW));
         assertTrue(wl.isToWildcard(TW));
@@ -176,17 +174,17 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
     ///         governance's. Reverting also catches an uninitialized array element in a governance
     ///         script, which would otherwise vanish silently.
     function test_updatePreconfs_allZeroPair_reverts() external {
-        _asCrossDomain(AUTHORIZED_L1);
+        _asL1(AUTHORIZED_L1);
         vm.expectRevert("PreconfWhitelist: pair is all-zero");
-        wl.updatePreconfs(++govNonce, _one(address(0), address(0)), _none());
+        wl.updatePreconfs(_one(address(0), address(0)), _none());
     }
 
     /// @notice The all-zero check applies to removes as well, so a malformed revoke cannot be
     ///         mistaken for a no-op.
     function test_updatePreconfs_allZeroPairInRemove_reverts() external {
-        _asCrossDomain(AUTHORIZED_L1);
+        _asL1(AUTHORIZED_L1);
         vm.expectRevert("PreconfWhitelist: pair is all-zero");
-        wl.updatePreconfs(++govNonce, _none(), _one(address(0), address(0)));
+        wl.updatePreconfs(_none(), _one(address(0), address(0)));
     }
 
     /// @notice No normalization across the sets: an exact pair and a covering wildcard coexist, and
@@ -341,158 +339,120 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
         assertEq(wl.exactPairIndex(address(0xA1), address(0xB1)), 0);
     }
 
-    // ===== authorization: design doc §5.2 attacks B and C =====
+    // ===== authorization: the alias gate =====
 
-    /// @notice Attack B — deposit aimed straight at this contract, bypassing the messenger. This is
-    ///         the negative face of gate 1.
-    /// @dev    The positive face — that the contract's hardcoded `MESSENGER` literal really is
-    ///         `Predeploys.L2_CROSS_DOMAIN_MESSENGER` — needs no test of its own. `L2Messenger` is
-    ///         declared *as* that predeploy in `CommonTest.t.sol`, and gate 1 admits only
-    ///         `msg.sender == MESSENGER`, so every passing `_gov` call in this file already proves
-    ///         the two are equal. A separate `assertEq(Predeploys.X, 0x42..07)` would assert
-    ///         nothing about this contract, since `MESSENGER` is `internal` and unreachable here.
-    function test_updatePreconfs_notMessenger_reverts() external {
+    /// @notice An ordinary L2 caller with no alias relationship to the governor.
+    function test_updatePreconfs_arbitraryCaller_reverts() external {
         vm.prank(alice);
-        vm.expectRevert("PreconfWhitelist: caller is not the messenger");
-        wl.updatePreconfs(++govNonce, _one(address(0x9999), address(0x8888)), _none());
+        vm.expectRevert("PreconfWhitelist: caller is not the authorized L1 sender");
+        wl.updatePreconfs(_one(address(0x9999), address(0x8888)), _none());
     }
 
-    /// @notice Attack C — a legitimate but unauthorized L1 caller relaying through the messenger.
+    /// @notice A legitimate but unauthorized L1 depositor: correctly aliased, wrong address.
     function test_updatePreconfs_unauthorizedL1Sender_reverts() external {
-        _asCrossDomain(alice);
+        _asL1(alice);
         vm.expectRevert("PreconfWhitelist: caller is not the authorized L1 sender");
-        wl.updatePreconfs(++govNonce, _one(address(0x9999), address(0x8888)), _none());
+        wl.updatePreconfs(_one(address(0x9999), address(0x8888)), _none());
     }
 
-    /// @notice The messenger address itself is not privileged — reaching us with a zero
-    ///         `xDomainMessageSender` (i.e. not mid-relay) must still fail gate 2.
-    function test_updatePreconfs_zeroXDomainSender_reverts() external {
-        _asCrossDomain(address(0));
+    /// @notice **The test that pins the gate's shape.** `AUTHORIZED_L1` reaching us *unaliased* is
+    ///         refused, because the gate compares `undoL1ToL2Alias(msg.sender)` rather than
+    ///         `msg.sender`.
+    /// @dev    Not a hypothetical. An EOA depositing through the portal is the one caller that is
+    ///         **not** aliased (`msg.sender == tx.origin`), so this is exactly what an EOA
+    ///         governor's message would look like on arrival — and it must fail, or the contract
+    ///         would appear to work while `authorizedL1` was set to an unusable address.
+    ///
+    ///         It is also what makes the impersonation argument hold: were the raw address
+    ///         accepted, any L1 contract deployed at `AUTHORIZED_L1` on the L1 side could speak for
+    ///         the same address on L2. Deleting this test would leave that unguarded, since every
+    ///         other test here passes through `_asL1` and so never exercises the raw form.
+    function test_updatePreconfs_unaliasedAuthorizedL1_reverts() external {
+        vm.prank(AUTHORIZED_L1);
         vm.expectRevert("PreconfWhitelist: caller is not the authorized L1 sender");
-        wl.updatePreconfs(++govNonce, _one(address(0x9999), address(0x8888)), _none());
+        wl.updatePreconfs(_one(address(0x9999), address(0x8888)), _none());
     }
 
-    // ===== replay guard: the governance nonce =====
-    //
-    // A relayed message that fails lands in the messenger's `failedMessages` mapping, from where
-    // anyone may replay it forever. The nonce is what stops a months-old delta from being applied
-    // at a moment of the replayer's choosing. See `localNonce`'s docs for what it does not cover.
-
-    /// @notice The counter starts at zero, so the first accepted message must carry at least 1.
-    function test_updatePreconfs_nonceStartsAtZero_succeeds() external {
-        assertEq(wl.localNonce(), 0, "a fresh deployment has consumed no nonce");
-
-        _asCrossDomain(AUTHORIZED_L1);
-        wl.updatePreconfs(1, _one(address(0x5555), address(0x6666)), _none());
-        assertEq(wl.localNonce(), 1);
+    /// @notice **Channel exclusivity.** A message relayed through the CrossDomainMessenger arrives
+    ///         with the L2 messenger predeploy as `msg.sender`, whose alias preimage is an
+    ///         unrelated address — so the wrong channel reverts rather than taking effect.
+    /// @dev    The operational constraint this pins is that governance must call
+    ///         `OptimismPortal.depositTransaction` directly and never
+    ///         `L1CrossDomainMessenger.sendMessage`. Asserting it here makes the constraint
+    ///         fail-closed by test as well as by construction.
+    function test_updatePreconfs_viaCrossDomainMessenger_reverts() external {
+        vm.prank(Predeploys.L2_CROSS_DOMAIN_MESSENGER);
+        vm.expectRevert("PreconfWhitelist: caller is not the authorized L1 sender");
+        wl.updatePreconfs(_one(address(0x9999), address(0x8888)), _none());
     }
 
-    /// @notice The guard is strict: re-sending the nonce that was just consumed is refused. This is
-    ///         the case that matters, because it is exactly what a replay of the most recent
-    ///         message looks like from this contract's side.
-    function test_updatePreconfs_replayingTheConsumedNonce_reverts() external {
-        _asCrossDomain(AUTHORIZED_L1);
-        wl.updatePreconfs(5, _one(address(0xA1), address(0xB1)), _none());
+    // ===== authorization: rotation =====
 
-        _asCrossDomain(AUTHORIZED_L1);
-        vm.expectRevert("PreconfWhitelist: stale nonce");
-        wl.updatePreconfs(5, _one(address(0xA2), address(0xB2)), _none());
+    /// @notice A rotation moves the privilege wholesale: the new address gains it and the old one
+    ///         loses it in the same call. Asserting only the first half would pass for a setter
+    ///         that appended to an allowlist of governors.
+    function test_setAuthorizedL1_movesThePrivilege_succeeds() external {
+        address newGov = address(0x9E01);
+
+        _asL1(AUTHORIZED_L1);
+        wl.setAuthorizedL1(newGov);
+        assertEq(wl.authorizedL1(), newGov);
+
+        // The new governor can update ...
+        _asL1(newGov);
+        wl.updatePreconfs(_one(address(0x5555), address(0x6666)), _none());
+        assertTrue(wl.isExactPair(address(0x5555), address(0x6666)));
+
+        // ... and the old one cannot.
+        _asL1(AUTHORIZED_L1);
+        vm.expectRevert("PreconfWhitelist: caller is not the authorized L1 sender");
+        wl.updatePreconfs(_one(address(0x7777), address(0x8888)), _none());
     }
 
-    /// @notice The scenario the guard exists for: a stale delta replayed after a newer message
-    ///         moved the allowlist on. Without the nonce this would silently re-authorize traffic
-    ///         governance had revoked, at a moment the replayer picks.
-    function test_updatePreconfs_staleDeltaAfterNewerMessage_revertsAndChangesNothing() external {
-        // Governance authorizes A1 -> B1 at nonce 7 ...
-        _asCrossDomain(AUTHORIZED_L1);
-        wl.updatePreconfs(7, _one(address(0xA1), address(0xB1)), _none());
-        assertTrue(wl.isExactPair(address(0xA1), address(0xB1)));
+    function test_setAuthorizedL1_emitsBothEnds_succeeds() external {
+        address newGov = address(0x9E01);
 
-        // ... then revokes it at nonce 8.
-        _asCrossDomain(AUTHORIZED_L1);
-        wl.updatePreconfs(8, _none(), _one(address(0xA1), address(0xB1)));
-        assertFalse(wl.isExactPair(address(0xA1), address(0xB1)));
+        vm.expectEmit(true, true, true, true, address(wl));
+        emit AuthorizedL1Updated(AUTHORIZED_L1, newGov);
 
-        // Replaying the nonce-7 message would re-authorize it. It must not.
-        _asCrossDomain(AUTHORIZED_L1);
-        vm.expectRevert("PreconfWhitelist: stale nonce");
-        wl.updatePreconfs(7, _one(address(0xA1), address(0xB1)), _none());
-
-        assertFalse(wl.isExactPair(address(0xA1), address(0xB1)), "the revocation stands");
-        assertEq(wl.localNonce(), 8, "a refused message consumes nothing");
+        _asL1(AUTHORIZED_L1);
+        wl.setAuthorizedL1(newGov);
     }
 
-    /// @notice Gaps are allowed — the nonce only has to increase. Governance may therefore source
-    ///         it from `L1CrossDomainMessenger.messageNonce()`, which counts all bridge traffic and
-    ///         so advances in large jumps between two governance messages.
-    function test_updatePreconfs_nonceMayJump_succeeds() external {
-        _asCrossDomain(AUTHORIZED_L1);
-        wl.updatePreconfs(1, _one(address(0xA1), address(0xB1)), _none());
+    /// @notice The setter is gated by the same modifier as `updatePreconfs`, so an unauthorized
+    ///         caller cannot seize governance. Aliased-but-wrong is the interesting case: it proves
+    ///         the gate is checked, not merely that a raw caller is rejected.
+    function test_setAuthorizedL1_unauthorizedCaller_reverts() external {
+        _asL1(alice);
+        vm.expectRevert("PreconfWhitelist: caller is not the authorized L1 sender");
+        wl.setAuthorizedL1(alice);
 
-        _asCrossDomain(AUTHORIZED_L1);
-        wl.updatePreconfs(9_000_000, _one(address(0xA2), address(0xB2)), _none());
-
-        assertEq(wl.localNonce(), 9_000_000);
-        assertTrue(wl.isExactPair(address(0xA2), address(0xB2)));
+        assertEq(wl.authorizedL1(), AUTHORIZED_L1, "the governor is unchanged");
     }
 
-    /// @notice A legitimate retry after a failure still works. The failed message never reached
-    ///         this contract's body, so it consumed no nonce — replaying it finds the counter
-    ///         exactly where it left it. Losing this would make the guard worse than the problem,
-    ///         since out-of-gas is the one failure a replay is *supposed* to fix.
-    /// @dev    The failure is modelled with the batch guard rather than a real OOG: both leave the
-    ///         counter untouched, and the batch guard is deterministic enough to assert on.
-    function test_updatePreconfs_retryAfterFailureKeepsItsNonce_succeeds() external {
-        _asCrossDomain(AUTHORIZED_L1);
-        wl.updatePreconfs(3, _one(address(0xA1), address(0xB1)), _none());
+    /// @notice Rotating to zero would disable governance permanently, and disabling the fast path
+    ///         is the node operator's switch rather than a state this contract can enter. Matches
+    ///         the constructor's guard, so both entry points agree about the one refused value.
+    function test_setAuthorizedL1_zeroAddress_reverts() external {
+        _asL1(AUTHORIZED_L1);
+        vm.expectRevert("PreconfWhitelist: authorized L1 sender is the zero address");
+        wl.setAuthorizedL1(address(0));
 
-        PreconfWhitelist.Rule[] memory over = _pairBatch(wl.MAX_BATCH() + 1, 0);
-        _asCrossDomain(AUTHORIZED_L1);
-        vm.expectRevert("PreconfWhitelist: batch too large");
-        wl.updatePreconfs(4, over, _none());
-        assertEq(wl.localNonce(), 3, "a failed message consumes no nonce");
-
-        // The corrected message reuses nonce 4 and lands.
-        _asCrossDomain(AUTHORIZED_L1);
-        wl.updatePreconfs(4, _one(address(0xA2), address(0xB2)), _none());
-        assertEq(wl.localNonce(), 4);
-        assertTrue(wl.isExactPair(address(0xA2), address(0xB2)));
+        assertEq(wl.authorizedL1(), AUTHORIZED_L1, "the governor is unchanged");
     }
 
-    /// @notice The documented remedy for "governance failed, then reconsidered and sent nothing
-    ///         more": an empty update whose only job is to burn the nonce. Two empty arrays are
-    ///         valid input and cost almost nothing, so this message cannot itself run out of gas —
-    ///         which is what makes it a reliable way to close the replay window.
-    function test_updatePreconfs_emptyUpdateBurnsTheNonce_succeeds() external {
-        _asCrossDomain(AUTHORIZED_L1);
-        wl.updatePreconfs(10, _one(address(0xA1), address(0xB1)), _none());
+    /// @notice Rotation touches governance only — the three sets and the layout marker are not
+    ///         part of it. A setter that reset state would be a silent way to empty the allowlist.
+    function test_setAuthorizedL1_leavesTheAllowlistAlone_succeeds() external {
+        _asL1(AUTHORIZED_L1);
+        wl.setAuthorizedL1(address(0x9E01));
+
         (uint256 p, uint256 f, uint256 t) = _counts();
-
-        // Say nonce 11 failed and will never be re-sent. Burn it.
-        _asCrossDomain(AUTHORIZED_L1);
-        wl.updatePreconfs(12, _none(), _none());
-        assertEq(wl.localNonce(), 12, "the window for 11 is now closed");
-
-        (uint256 p2, uint256 f2, uint256 t2) = _counts();
-        assertEq(p2, p, "an empty update changes no rule");
-        assertEq(f2, f);
-        assertEq(t2, t);
-
-        _asCrossDomain(AUTHORIZED_L1);
-        vm.expectRevert("PreconfWhitelist: stale nonce");
-        wl.updatePreconfs(11, _one(address(0xBAD), address(0xBAD)), _none());
-    }
-
-    /// @notice The nonce guard runs before the batch guard. Both would reject an oversized *and*
-    ///         stale message; asserting the order pins which error the caller is shown.
-    function test_updatePreconfs_nonceGuardPrecedesBatchGuard_reverts() external {
-        _asCrossDomain(AUTHORIZED_L1);
-        wl.updatePreconfs(20, _none(), _none());
-
-        PreconfWhitelist.Rule[] memory over = _pairBatch(wl.MAX_BATCH() + 1, 0);
-        _asCrossDomain(AUTHORIZED_L1);
-        vm.expectRevert("PreconfWhitelist: stale nonce");
-        wl.updatePreconfs(20, over, _none());
+        assertEq(p, 1);
+        assertEq(f, 1);
+        assertEq(t, 1);
+        assertTrue(wl.isExactPair(P_FROM, P_TO));
+        assertEq(wl.layoutVersion(), 2);
     }
 
     // ===== batch guard =====
@@ -503,8 +463,7 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
         out_ = new PreconfWhitelist.Rule[](_n);
         for (uint256 i = 0; i < _n; i++) {
             out_[i] = PreconfWhitelist.Rule({
-                from: address(uint160(_seed + i + 1)),
-                to: address(uint160(_seed + i + 0x100000))
+                from: address(uint160(_seed + i + 1)), to: address(uint160(_seed + i + 0x100000))
             });
         }
     }
@@ -518,16 +477,16 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
 
     /// @notice Also asserts that nothing changed: the guard reverts before any SSTORE, so a
     ///         rejected governance message is cheap and leaves no partial application behind.
-    /// @dev    The batch is built *before* `_asCrossDomain`, deliberately. `wl.MAX_BATCH()` is an
+    /// @dev    The batch is built *before* `_asL1`, deliberately. `wl.MAX_BATCH()` is an
     ///         external call; evaluated inside the argument list it would consume the `vm.prank`
     ///         and the `vm.expectRevert`, leaving the test to assert against the wrong call. That
     ///         mistake passes as a green test, so it is worth the extra line.
     function test_updatePreconfs_overMaxBatch_revertsAndChangesNothing() external {
         PreconfWhitelist.Rule[] memory over = _pairBatch(wl.MAX_BATCH() + 1, 0);
 
-        _asCrossDomain(AUTHORIZED_L1);
+        _asL1(AUTHORIZED_L1);
         vm.expectRevert("PreconfWhitelist: batch too large");
-        wl.updatePreconfs(++govNonce, over, _none());
+        wl.updatePreconfs(over, _none());
 
         (uint256 p, uint256 f, uint256 t) = _counts();
         assertEq(p, 1);
@@ -538,9 +497,9 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
     /// @notice The cap is on the SUM across both arguments, not per-array.
     function test_updatePreconfs_sumAcrossArgsExceedsMax_reverts() external {
         uint256 max = wl.MAX_BATCH();
-        _asCrossDomain(AUTHORIZED_L1);
+        _asL1(AUTHORIZED_L1);
         vm.expectRevert("PreconfWhitelist: batch too large");
-        wl.updatePreconfs(++govNonce, _pairBatch(max / 2 + 1, 0), _pairBatch(max / 2 + 1, 0x1000000));
+        wl.updatePreconfs(_pairBatch(max / 2 + 1, 0), _pairBatch(max / 2 + 1, 0x1000000));
     }
 
     // ===== pagination =====
@@ -835,18 +794,26 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
         assertEq(wl.LAYOUT_VERSION(), 2);
     }
 
-    /// @notice `localNonce` is appended *after* `layoutVersion`, so adding it moved none of the
-    ///         slots op-reth reads — which is why it did not bump `LAYOUT_VERSION`. Asserting the
-    ///         slot number is the guard: an accidental insertion higher up would slide `layoutVersion`
-    ///         off slot 6 and every array with it, and the Rust side would read garbage while still
-    ///         seeing the version it expects.
-    function test_storageLayout_localNonceIsAppendedAtSlot7_succeeds() external {
-        _asCrossDomain(AUTHORIZED_L1);
-        wl.updatePreconfs(42, _none(), _none());
+    /// @notice `authorizedL1` is appended *after* `layoutVersion`, so it moves none of the slots
+    ///         op-reth reads — which is why it does not bump `LAYOUT_VERSION`. Asserting the slot
+    ///         number is the guard, and it matters more for this variable than for any other:
+    ///         `authorizedL1` is the one piece of configuration a reader would naturally declare at
+    ///         the *top* of the contract, next to the constants, which would put it in slot 0 and
+    ///         slide every array down one. op-reth would then read `exactPairIndex` as `exactPairs`
+    ///         and `fromWildcardIndex` as `fromWildcards`, while `layoutVersion` — moved to slot 7
+    ///         — read back as 0 and produced an error naming the wrong cause.
+    ///
+    ///         Asserted after a rotation rather than on the constructor's value, so that a setter
+    ///         writing to some other slot cannot pass by leaving the constructor's write in place.
+    function test_storageLayout_authorizedL1IsAppendedAtSlot7_succeeds() external {
+        address newGov = address(0x9E01);
+        _asL1(AUTHORIZED_L1);
+        wl.setAuthorizedL1(newGov);
 
-        assertEq(uint256(vm.load(address(wl), bytes32(uint256(7)))), 42, "localNonce must be slot 7");
-        assertEq(wl.localNonce(), 42);
+        assertEq(_addrAt(bytes32(0), 7), newGov, "authorizedL1 must be slot 7");
+        assertEq(wl.authorizedL1(), newGov);
         assertEq(uint256(vm.load(address(wl), bytes32(uint256(6)))), 2, "layoutVersion still slot 6");
+        assertEq(uint256(vm.load(address(wl), bytes32(uint256(0)))), 1, "exactPairs still slot 0");
         assertEq(wl.LAYOUT_VERSION(), 2, "appending a variable is not a layout change");
     }
 
@@ -891,40 +858,41 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
     // ===== MAX_BATCH sizing =====
     //
     // `MAX_BATCH = 256` is calibrated so that a full batch of the most expensive rule form fits in
-    // the gas a governance message can actually be given. That budget comes from **L1**, not from
-    // the L2 block: `OptimismPortal.depositTransaction` is `metered`, so `ResourceMetering` caps the
-    // deposit gas bought per L1 block at `maxResourceLimit` (20,000,000), and
-    // `CrossDomainMessenger.baseGas` spends 683,664 of it on overhead before the EIP-150 63/64 term
-    // — leaving 19,014,519 of `_minGasLimit`. The full derivation is on `MAX_BATCH` in
-    // `PreconfWhitelist.sol`; extrapolating the figures below puts the hard ceiling at 275.
+    // the gas a governance deposit can actually be given. That budget comes from **L1**, not from
+    // the L2 block: `OptimismPortal.depositTransaction` is `metered(_gasLimit)`, so it meters what
+    // governance asks for directly — no `baseGas` conversion, no EIP-150 63/64 term on this channel
+    // — and `ResourceMetering` caps the deposit gas bought per L1 block at `maxResourceLimit`
+    // (20,000,000). Subtracting the deposit's own worst-case intrinsic cost (285,256 for a full
+    // batch's 16,516 calldata bytes) leaves 19,714,744. The full derivation is on `MAX_BATCH` in
+    // `PreconfWhitelist.sol`; extrapolating the figures below puts the hard ceiling at 289.
     //
     // That justification lives entirely in the two measurements below, so they assert the ceiling
     // rather than only logging. A change that inflates per-rule cost has to either stay under the
     // bound or force whoever made it to re-derive `MAX_BATCH` — which is the point. The pair bound
-    // is the real 19,014,519 figure, which sits 6.7% above the recorded cost, so compiler-version
+    // is the real 19,714,744 figure, which sits 13.2% above the recorded cost, so compiler-version
     // noise is not a tripwire. Run with `-vv` to read the numbers; if a bound trips, re-measure and
     // update the table in `PreconfWhitelist.sol`.
 
     /// @notice A full `MAX_BATCH` of exact-pair adds — the expensive form `MAX_BATCH` is sized
-    ///         against. Recorded at 17,734,481 (69,275 per rule).
+    ///         against. Recorded at 17,419,375 (68,044 per rule).
     function test_gas_maxBatchOfPairAdds() external {
         uint256 max = wl.MAX_BATCH();
         PreconfWhitelist.Rule[] memory adds = _pairBatch(max, 0);
-        _asCrossDomain(AUTHORIZED_L1);
+        _asL1(AUTHORIZED_L1);
 
         uint256 g = gasleft();
-        wl.updatePreconfs(++govNonce, adds, _none());
+        wl.updatePreconfs(adds, _none());
         uint256 used = g - gasleft();
 
         console.log("MAX_BATCH             ", max);
         console.log("gas, all pair adds    ", used);
         console.log("gas per pair add      ", used / max);
 
-        assertLt(used, 19_014_519, "a full batch must fit in the _minGasLimit L1 can pay for -- re-derive MAX_BATCH");
+        assertLt(used, 19_714_744, "a full batch must fit in the _gasLimit L1 can sell -- re-derive MAX_BATCH");
     }
 
     /// @notice The same batch made entirely of wildcards, to confirm the pair form really is the
-    ///         expensive one. Recorded at 11,987,007 (46,824 per rule).
+    ///         expensive one. Recorded at 11,700,841 (45,706 per rule).
     /// @dev    Bounded above by the pair figure as well as by an absolute number: if a wildcard add
     ///         ever became the costlier of the two, `MAX_BATCH` would be sized against the wrong
     ///         operation and the ceiling above would stop being an upper bound at all.
@@ -934,16 +902,16 @@ contract PreconfWhitelist_Test is Messenger_Initializer {
         for (uint256 i = 0; i < max; i++) {
             adds[i] = _p(address(uint160(i + 1)), address(0));
         }
-        _asCrossDomain(AUTHORIZED_L1);
+        _asL1(AUTHORIZED_L1);
 
         uint256 g = gasleft();
-        wl.updatePreconfs(++govNonce, adds, _none());
+        wl.updatePreconfs(adds, _none());
         uint256 used = g - gasleft();
 
         console.log("gas, all wildcard adds", used);
         console.log("gas per wildcard add  ", used / max);
 
         assertLt(used, 12_400_000, "wildcard adds got more expensive -- re-measure");
-        assertLt(used, 17_734_481, "the exact-pair form must stay the expensive one");
+        assertLt(used, 17_419_375, "the exact-pair form must stay the expensive one");
     }
 }

--- a/packages/contracts-bedrock/test/PreconfWhitelist.t.sol
+++ b/packages/contracts-bedrock/test/PreconfWhitelist.t.sol
@@ -892,6 +892,24 @@ contract PreconfWhitelist_Test is Portal_Initializer {
         assertLt(used, 19_714_744, "a full batch must fit in the _gasLimit L1 can sell -- re-derive MAX_BATCH");
     }
 
+    /// @notice A **single** pair add — the un-amortized cost. `MAX_BATCH`'s figure above is an
+    ///         average over 256 rules, which divides the per-call fixed cost (dispatch, calldata
+    ///         decode, the three cold SLOADs the event reads, the cold length SSTORE) by 256; a
+    ///         one-rule call pays all of it. This is the number `PreconfWhitelistGov.BASE_GAS`
+    ///         exists to cover, and it is measured here because only the L2 side can measure it.
+    function test_gas_singleRuleAdd() external {
+        _asL1(AUTHORIZED_L1);
+
+        uint256 g = gasleft();
+        wl.updatePreconfs(_one(address(0xA9), address(0xB9)), _none());
+        uint256 used = g - gasleft();
+
+        console.log("gas, single pair add  ", used);
+        console.log("gas, per-rule average ", uint256(68_044));
+        console.log("un-amortized excess   ", used - 68_044);
+        assertLt(used, 100_000, "single add got more expensive -- re-derive PreconfWhitelistGov.BASE_GAS");
+    }
+
     /// @notice The same batch made entirely of wildcards, to confirm the pair form really is the
     ///         expensive one. Recorded at 11,700,841 (45,706 per rule).
     /// @dev    Bounded above by the pair figure as well as by an absolute number: if a wildcard add

--- a/packages/contracts-bedrock/test/PreconfWhitelistGov.t.sol
+++ b/packages/contracts-bedrock/test/PreconfWhitelistGov.t.sol
@@ -209,10 +209,9 @@ contract PreconfWhitelistGov_Test is Portal_Initializer {
         gov.updatePreconfs(a, b);
     }
 
-    /// @notice **On the explicit path the only floor is the portal's**, and it is calibrated for
-    ///         calldata rather than execution: it rules out the absurd values without pretending to
-    ///         know what a batch costs on L2. Sufficiency is the caller's problem here — that is the
-    ///         whole difference from `updatePreconfs`, which sizes the gas itself.
+    /// @notice **On the explicit path the only floor is the portal's**, calibrated for calldata
+    ///         rather than execution: it rules out absurd values without knowing the L2 cost.
+    ///         Sufficiency is the caller's problem — the whole difference from `updatePreconfs`.
     function test_updatePreconfsWithGasLimit_belowPortalGasFloor_reverts() external {
         PreconfWhitelist.Rule[] memory add = _one(address(0x1111), address(0x2222));
         bytes memory data = abi.encodeCall(PreconfWhitelist.updatePreconfs, (add, _none()));
@@ -245,7 +244,7 @@ contract PreconfWhitelistGov_Test is Portal_Initializer {
         PreconfWhitelist.Rule[] memory add = _one(address(0x1111), address(0x2222));
         PreconfWhitelist.Rule[] memory remove = _one(address(0x3333), address(0x4444));
         bytes memory data = abi.encodeCall(PreconfWhitelist.updatePreconfs, (add, remove));
-        uint64 expected = op.minimumGasLimit(uint64(data.length)) + 2 * 70_000;
+        uint64 expected = op.minimumGasLimit(uint64(data.length)) + gov.BASE_GAS() + 2 * gov.GAS_PER_RULE();
 
         assertEq(gov.GAS_PER_RULE(), 70_000);
         vm.expectEmit(true, true, true, true, address(gov));
@@ -255,16 +254,38 @@ contract PreconfWhitelistGov_Test is Portal_Initializer {
         gov.updatePreconfs(add, remove);
     }
 
-    /// @notice **The coupling that would otherwise break silently.** `GAS_PER_RULE` carries a margin
-    ///         over the measured cost, so the computed limit runs into `maxResourceLimit` before the
-    ///         batch cap does — at 282 rules against `MAX_BATCH`'s 256. Raising the cap past 281
-    ///         leaves the explicit path working and the default one reverting inside `metered`.
+    /// @notice **The coupling that would otherwise break silently.** The computed limit runs into
+    ///         `maxResourceLimit` at 282 rules, before `MAX_BATCH`'s 256 does — raise the cap past
+    ///         281 and the explicit path keeps working while the default one reverts in `metered`.
     function test_updatePreconfs_computedLimitAtMaxBatchFitsTheDepositCap_succeeds() external view {
         uint256 max = gov.MAX_BATCH();
         uint64 calldataLen = uint64(132 + 64 * max); // selector + two offsets + two lengths + 64/rule
-        uint256 computed = op.minimumGasLimit(calldataLen) + gov.GAS_PER_RULE() * max;
+        uint256 computed = op.minimumGasLimit(calldataLen) + gov.BASE_GAS() + gov.GAS_PER_RULE() * max;
 
         assertLe(computed, op.SYSTEM_CONFIG().resourceConfig().maxResourceLimit);
+    }
+
+    /// @notice **Whether the formula is sufficient, not merely self-consistent.** The two above
+    ///         re-derive it or bound it from above; neither catches under-buying, which is a property
+    ///         of L2 execution. So this one measures a real rule add and asserts the limit covers it.
+    /// @dev    `gasleft()` measures execution, not intrinsic — `minimumGasLimit` covers that and
+    ///         always over-covers, charging 16 per byte where zero bytes really cost 4. One rule is
+    ///         the worst case: the fixed term is spread over nothing, so larger batches are cheaper.
+    function test_updatePreconfs_computedLimitCoversTheL2Execution_succeeds() external {
+        PreconfWhitelist wl = new PreconfWhitelist(address(gov), _none());
+        PreconfWhitelist.Rule[] memory add = _one(address(0x1111), address(0x2222));
+        bytes memory data = abi.encodeCall(PreconfWhitelist.updatePreconfs, (add, _none()));
+
+        uint256 buys = op.minimumGasLimit(uint64(data.length)) + gov.BASE_GAS() + gov.GAS_PER_RULE();
+
+        // As the portal-aliased Gov, which is the real `msg.sender` on L2.
+        vm.prank(AddressAliasHelper.applyL1ToL2Alias(address(gov)));
+        uint256 g = gasleft();
+        wl.updatePreconfs(add, _none());
+        uint256 spends = g - gasleft();
+
+        assertGt(buys, spends, "computed limit must cover a one-rule call -- raise BASE_GAS");
+        assertLt(spends, gov.BASE_GAS() + gov.GAS_PER_RULE(), "the fixed+per-rule terms alone must cover execution");
     }
 
     // ===== rotateAuthorizedL1 =====
@@ -295,10 +316,9 @@ contract PreconfWhitelistGov_Test is Portal_Initializer {
         gov.rotateAuthorizedL1(address(0));
     }
 
-    /// @notice A contract passes, and the deposit carries the `setAuthorizedL1` call rather than an
-    ///         `updatePreconfs` one — the two paths share `_deposit`, so the calldata is the only
-    ///         thing that distinguishes them. The gas is `ROTATE_GAS` over the portal's floor, with
-    ///         no input involved: a rotation's cost on L2 does not depend on what is rotated to.
+    /// @notice A contract passes, and the deposit carries `setAuthorizedL1` rather than an
+    ///         `updatePreconfs` call — the two share `_deposit`, so the calldata is all that tells
+    ///         them apart. The gas is `ROTATE_GAS` over the floor, with no input involved.
     function test_rotateAuthorizedL1_contract_succeeds() external {
         address newGov = address(new PreconfWhitelistGov(op, OWNER));
         bytes memory data = abi.encodeCall(PreconfWhitelist.setAuthorizedL1, (newGov));

--- a/packages/contracts-bedrock/test/PreconfWhitelistGov.t.sol
+++ b/packages/contracts-bedrock/test/PreconfWhitelistGov.t.sol
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Portal_Initializer } from "./CommonTest.t.sol";
+import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
+import { OptimismPortal } from "src/L1/OptimismPortal.sol";
+import { PreconfWhitelist } from "src/L2/PreconfWhitelist.sol";
+import { PreconfWhitelistGov } from "src/L1/PreconfWhitelistGov.sol";
+
+/// @title PreconfWhitelistGov_Test
+/// @notice Tests the L1 endpoint that governs `PreconfWhitelist`. Three things are worth asserting
+///         here and are not covered by the L2 suite: the two guards only this side can run (the
+///         batch cap and the has-code check), the exact shape of the deposit it buys, and — the
+///         cross-chain seam — that the `from` the portal derives is the address the L2 gate admits.
+contract PreconfWhitelistGov_Test is Portal_Initializer {
+    /// @notice `OptimismPortal.DEPOSIT_VERSION`. Internal there, so it is restated rather than read.
+    uint256 internal constant DEPOSIT_VERSION = 1;
+
+    address internal constant OWNER = address(0xA5A5);
+
+    PreconfWhitelistGov internal gov;
+    address internal whitelistL2;
+
+    // `TransactionDeposited` is inherited from `CommonTest`, which declares it for the portal.
+    event WhitelistSet(address indexed whitelist);
+    event GovernanceDeposited(address indexed target, uint64 gasLimit, bytes data);
+
+    function setUp() public virtual override {
+        super.setUp();
+        gov = new PreconfWhitelistGov(op, OWNER);
+        whitelistL2 = address(0xBEEF);
+        vm.prank(OWNER);
+        gov.setWhitelist(whitelistL2);
+    }
+
+    // ===== helpers =====
+
+    function _one(address _from, address _to) internal pure returns (PreconfWhitelist.Rule[] memory out_) {
+        out_ = new PreconfWhitelist.Rule[](1);
+        out_[0] = PreconfWhitelist.Rule({ from: _from, to: _to });
+    }
+
+    function _none() internal pure returns (PreconfWhitelist.Rule[] memory out_) {
+        out_ = new PreconfWhitelist.Rule[](0);
+    }
+
+    /// @notice The `opaqueData` the portal emits for a zero-value deposit carrying `_data`.
+    /// @dev    Mirrors `OptimismPortal.depositTransaction`'s
+    ///         `abi.encodePacked(_mntValue, _mntTxValue, msg.value, _ethTxValue, _gasLimit,
+    ///         _isCreation, _data)`. Written out in full rather than pulled from a helper so that a
+    ///         value silently becoming non-zero — MNT in particular, which the portal would pull
+    ///         from the governance contract — fails the assertion.
+    function _opaque(uint64 _gasLimit, bytes memory _data) internal pure returns (bytes memory) {
+        return abi.encodePacked(uint256(0), uint256(0), uint256(0), uint256(0), _gasLimit, false, _data);
+    }
+
+    // ===== constructor =====
+
+    function test_constructor_setsPortalAndOwner_succeeds() external view {
+        assertEq(address(gov.PORTAL()), address(op));
+        assertEq(gov.owner(), OWNER);
+    }
+
+    /// @notice Both caps resolve to the file-level `PRECONF_MAX_BATCH`, so they cannot drift at the
+    ///         source. Asserted against a real deployment rather than the literal 256: that is what
+    ///         would still catch someone re-hardcoding either side later.
+    function test_maxBatch_isTheSameConstantAsTheL2Contract_succeeds() external {
+        PreconfWhitelist wl = new PreconfWhitelist(address(0xA11CE), _none());
+        assertEq(gov.MAX_BATCH(), wl.MAX_BATCH());
+    }
+
+    function test_constructor_zeroPortal_reverts() external {
+        vm.expectRevert("PreconfWhitelistGov: portal is the zero address");
+        new PreconfWhitelistGov(OptimismPortal(payable(address(0))), OWNER);
+    }
+
+    function test_constructor_zeroOwner_reverts() external {
+        vm.expectRevert("PreconfWhitelistGov: owner is the zero address");
+        new PreconfWhitelistGov(op, address(0));
+    }
+
+    // ===== setWhitelist =====
+
+    function test_setWhitelist_succeeds() external {
+        vm.expectEmit(true, true, true, true, address(gov));
+        emit WhitelistSet(address(0xC0FFEE));
+
+        vm.prank(OWNER);
+        gov.setWhitelist(address(0xC0FFEE));
+        assertEq(gov.whitelist(), address(0xC0FFEE));
+    }
+
+    function test_setWhitelist_notOwner_reverts() external {
+        vm.prank(alice);
+        vm.expectRevert("Ownable: caller is not the owner");
+        gov.setWhitelist(address(0xC0FFEE));
+    }
+
+    // ===== the deposit itself =====
+
+    /// @notice **The cross-chain seam.** The portal aliases this contract on the way out, and the
+    ///         address it derives has to be the one `PreconfWhitelist.onlyL1Gov` admits — that gate
+    ///         undoes the alias and compares against `authorizedL1`. Asserting the round trip here
+    ///         is what ties the two repositories' halves together; each side alone proves nothing.
+    ///
+    ///         The aliasing happens at all only because this contract is a contract: the portal
+    ///         transforms the depositor exactly when `msg.sender != tx.origin`. That is the same
+    ///         property `rotateAuthorizedL1`'s has-code check exists to preserve.
+    function test_updatePreconfs_depositFromIsTheAliasTheL2GateExpects_succeeds() external {
+        address expectedFrom = AddressAliasHelper.applyL1ToL2Alias(address(gov));
+
+        // `from` is an indexed topic, so a mismatch fails here. Data is not checked — the payload
+        // has its own test; this one is about the address the portal derives.
+        vm.expectEmit(true, true, true, false, address(op));
+        emit TransactionDeposited(expectedFrom, whitelistL2, DEPOSIT_VERSION, "");
+
+        uint64 gasLimit = 200_000;
+        vm.prank(OWNER);
+        gov.updatePreconfs(_one(address(0x1111), address(0x2222)), _none(), gasLimit);
+
+        // And the transform `PreconfWhitelist.onlyL1Gov` applies inverts it back to this contract,
+        // which is what `authorizedL1` is set to. This is the round trip the two repos share.
+        assertEq(AddressAliasHelper.undoL1ToL2Alias(expectedFrom), address(gov));
+        assertTrue(expectedFrom != address(gov), "the alias must actually move the address");
+    }
+
+    /// @notice The whole deposit, field by field. The four value arguments must be zero — a non-zero
+    ///         `_mntValue` would make the portal pull MNT from this contract — and the calldata must
+    ///         be exactly the `updatePreconfs` call, since that is what op-reth decodes.
+    function test_updatePreconfs_depositsExactPayload_succeeds() external {
+        PreconfWhitelist.Rule[] memory add = _one(address(0x1111), address(0x2222));
+        uint64 gasLimit = 200_000;
+        bytes memory data = abi.encodeCall(PreconfWhitelist.updatePreconfs, (add, _none()));
+
+        vm.expectEmit(true, true, true, true, address(op));
+        emit TransactionDeposited(
+            AddressAliasHelper.applyL1ToL2Alias(address(gov)), whitelistL2, DEPOSIT_VERSION, _opaque(gasLimit, data)
+        );
+
+        vm.prank(OWNER);
+        gov.updatePreconfs(add, _none(), 200_000);
+    }
+
+    /// @notice The L1-side record, so an operator can see what was asked for without decoding the
+    ///         portal's packed `opaqueData`.
+    function test_updatePreconfs_emitsGovernanceDeposited_succeeds() external {
+        PreconfWhitelist.Rule[] memory add = _one(address(0x1111), address(0x2222));
+        uint64 gasLimit = 200_000;
+
+        vm.expectEmit(true, true, true, true, address(gov));
+        emit GovernanceDeposited(whitelistL2, gasLimit, abi.encodeCall(PreconfWhitelist.updatePreconfs, (add, _none())));
+
+        vm.prank(OWNER);
+        gov.updatePreconfs(add, _none(), 200_000);
+    }
+
+    function test_updatePreconfs_notOwner_reverts() external {
+        vm.prank(alice);
+        vm.expectRevert("Ownable: caller is not the owner");
+        gov.updatePreconfs(_one(address(0x1111), address(0x2222)), _none(), 200_000);
+    }
+
+    function test_updatePreconfs_whitelistNotSet_reverts() external {
+        PreconfWhitelistGov fresh = new PreconfWhitelistGov(op, OWNER);
+
+        vm.prank(OWNER);
+        vm.expectRevert("PreconfWhitelistGov: whitelist not set");
+        fresh.updatePreconfs(_one(address(0x1111), address(0x2222)), _none(), 200_000);
+    }
+
+    // ===== guards this side runs so L2 does not have to pay for them =====
+
+    /// @notice The batch mirror. An oversized batch reverts on L2 too, but only after the deposit
+    ///         gas has been bought and paid for on L1 — rejecting it here is free.
+    /// @dev    Any `gov.*` or `op.*` view is hoisted above the cheatcodes deliberately, here and
+    ///         throughout this file. Those are **external calls**: evaluated inside an argument list
+    ///         one would consume the `vm.prank` and then the `vm.expectRevert`, leaving the
+    ///         assertion pointed at the view instead of at `updatePreconfs`. The same note is on
+    ///         `test_updatePreconfs_overMaxBatch_revertsAndChangesNothing` in `PreconfWhitelist.t.sol`.
+    function test_updatePreconfs_overMaxBatch_reverts() external {
+        uint256 over = gov.MAX_BATCH() + 1;
+        PreconfWhitelist.Rule[] memory add = new PreconfWhitelist.Rule[](over);
+        for (uint256 i = 0; i < over; i++) {
+            add[i] = PreconfWhitelist.Rule({ from: address(uint160(i + 1)), to: address(uint160(i + 0x100000)) });
+        }
+
+        vm.prank(OWNER);
+        vm.expectRevert("PreconfWhitelistGov: batch too large");
+        gov.updatePreconfs(add, _none(), 200_000);
+    }
+
+    /// @notice The cap is on the sum across both arguments, matching the L2 contract.
+    function test_updatePreconfs_sumAcrossArgsExceedsMax_reverts() external {
+        uint256 half = gov.MAX_BATCH() / 2 + 1;
+        PreconfWhitelist.Rule[] memory a = new PreconfWhitelist.Rule[](half);
+        PreconfWhitelist.Rule[] memory b = new PreconfWhitelist.Rule[](half);
+        for (uint256 i = 0; i < half; i++) {
+            a[i] = PreconfWhitelist.Rule({ from: address(uint160(i + 1)), to: address(uint160(i + 0x100000)) });
+            b[i] = PreconfWhitelist.Rule({ from: address(uint160(i + 0x200000)), to: address(uint160(i + 0x300000)) });
+        }
+
+        vm.prank(OWNER);
+        vm.expectRevert("PreconfWhitelistGov: batch too large");
+        gov.updatePreconfs(a, b, 200_000);
+    }
+
+    /// @notice **The only floor left on `_gasLimit`, and it is the portal's.** This contract carries
+    ///         no gas estimate of its own: what a batch costs is a property of the L2 bytecode,
+    ///         which L1 cannot measure, so a constant here would be a stale copy that fails in the
+    ///         dangerous direction — under-estimating, and being trusted while it does.
+    ///
+    ///         What survives is `OptimismPortal.minimumGasLimit`, calibrated for calldata rather
+    ///         than execution. It rules out the absurd values without pretending to know the cost;
+    ///         sufficiency is checked by governance on L2, which is the only place it is knowable.
+    function test_updatePreconfs_belowPortalGasFloor_reverts() external {
+        PreconfWhitelist.Rule[] memory add = _one(address(0x1111), address(0x2222));
+        bytes memory data = abi.encodeCall(PreconfWhitelist.updatePreconfs, (add, _none()));
+        uint64 portalFloor = op.minimumGasLimit(uint64(data.length));
+
+        vm.prank(OWNER);
+        vm.expectRevert("OptimismPortal: gas limit too small");
+        gov.updatePreconfs(add, _none(), portalFloor - 1);
+
+        // Exactly the portal's floor is accepted, so this contract adds nothing above it.
+        vm.prank(OWNER);
+        gov.updatePreconfs(add, _none(), portalFloor);
+    }
+
+    // ===== rotateAuthorizedL1 =====
+
+    /// @notice **The guard only L1 can run.** `PreconfWhitelist` admits a caller by undoing the
+    ///         portal's alias, and the portal aliases a depositor exactly when it is a contract — so
+    ///         an EOA `authorizedL1` is permanently locked out of the L2 gate. L2 cannot check this
+    ///         (`extcodesize` there says nothing about an L1 address); this contract runs on L1 and
+    ///         can. `alice` is a plain EOA, which is also what a mistyped address looks like.
+    function test_rotateAuthorizedL1_eoa_reverts() external {
+        vm.prank(OWNER);
+        vm.expectRevert("PreconfWhitelistGov: authorized L1 sender is not a contract");
+        gov.rotateAuthorizedL1(alice, uint64(60_000));
+    }
+
+    function test_rotateAuthorizedL1_zeroAddress_reverts() external {
+        vm.prank(OWNER);
+        vm.expectRevert("PreconfWhitelistGov: authorized L1 sender is the zero address");
+        gov.rotateAuthorizedL1(address(0), uint64(60_000));
+    }
+
+    /// @notice A contract passes, and the deposit carries the `setAuthorizedL1` call rather than an
+    ///         `updatePreconfs` one — the two paths share `_deposit`, so the calldata is the only
+    ///         thing that distinguishes them.
+    function test_rotateAuthorizedL1_contract_succeeds() external {
+        address newGov = address(new PreconfWhitelistGov(op, OWNER));
+        uint64 gasLimit = 60_000;
+
+        vm.expectEmit(true, true, true, true, address(op));
+        emit TransactionDeposited(
+            AddressAliasHelper.applyL1ToL2Alias(address(gov)),
+            whitelistL2,
+            DEPOSIT_VERSION,
+            _opaque(gasLimit, abi.encodeCall(PreconfWhitelist.setAuthorizedL1, (newGov)))
+        );
+
+        vm.prank(OWNER);
+        gov.rotateAuthorizedL1(newGov, gasLimit);
+    }
+
+    function test_rotateAuthorizedL1_notOwner_reverts() external {
+        address newGov = address(new PreconfWhitelistGov(op, OWNER));
+
+        vm.prank(alice);
+        vm.expectRevert("Ownable: caller is not the owner");
+        gov.rotateAuthorizedL1(newGov, uint64(60_000));
+    }
+
+    // ===== ownership =====
+
+    /// @notice Renouncing would strand the L2 allowlist: only this contract can write to it, and
+    ///         reaching it needs an owner. `rotateAuthorizedL1` is the supported way out instead.
+    function test_renounceOwnership_reverts() external {
+        vm.prank(OWNER);
+        vm.expectRevert("PreconfWhitelistGov: ownership cannot be renounced");
+        gov.renounceOwnership();
+    }
+
+    function test_transferOwnership_succeeds() external {
+        vm.prank(OWNER);
+        gov.transferOwnership(alice);
+        assertEq(gov.owner(), alice);
+    }
+}

--- a/packages/contracts-bedrock/test/PreconfWhitelistGov.t.sol
+++ b/packages/contracts-bedrock/test/PreconfWhitelistGov.t.sol
@@ -114,9 +114,8 @@ contract PreconfWhitelistGov_Test is Portal_Initializer {
         vm.expectEmit(true, true, true, false, address(op));
         emit TransactionDeposited(expectedFrom, whitelistL2, DEPOSIT_VERSION, "");
 
-        uint64 gasLimit = 200_000;
         vm.prank(OWNER);
-        gov.updatePreconfs(_one(address(0x1111), address(0x2222)), _none(), gasLimit);
+        gov.updatePreconfs(_one(address(0x1111), address(0x2222)), _none());
 
         // And the transform `PreconfWhitelist.onlyL1Gov` applies inverts it back to this contract,
         // which is what `authorizedL1` is set to. This is the round trip the two repos share.
@@ -127,7 +126,7 @@ contract PreconfWhitelistGov_Test is Portal_Initializer {
     /// @notice The whole deposit, field by field. The four value arguments must be zero — a non-zero
     ///         `_mntValue` would make the portal pull MNT from this contract — and the calldata must
     ///         be exactly the `updatePreconfs` call, since that is what op-reth decodes.
-    function test_updatePreconfs_depositsExactPayload_succeeds() external {
+    function test_updatePreconfsWithGasLimit_depositsExactPayload_succeeds() external {
         PreconfWhitelist.Rule[] memory add = _one(address(0x1111), address(0x2222));
         uint64 gasLimit = 200_000;
         bytes memory data = abi.encodeCall(PreconfWhitelist.updatePreconfs, (add, _none()));
@@ -138,12 +137,12 @@ contract PreconfWhitelistGov_Test is Portal_Initializer {
         );
 
         vm.prank(OWNER);
-        gov.updatePreconfs(add, _none(), 200_000);
+        gov.updatePreconfsWithGasLimit(add, _none(), gasLimit);
     }
 
     /// @notice The L1-side record, so an operator can see what was asked for without decoding the
     ///         portal's packed `opaqueData`.
-    function test_updatePreconfs_emitsGovernanceDeposited_succeeds() external {
+    function test_updatePreconfsWithGasLimit_emitsGovernanceDeposited_succeeds() external {
         PreconfWhitelist.Rule[] memory add = _one(address(0x1111), address(0x2222));
         uint64 gasLimit = 200_000;
 
@@ -151,13 +150,19 @@ contract PreconfWhitelistGov_Test is Portal_Initializer {
         emit GovernanceDeposited(whitelistL2, gasLimit, abi.encodeCall(PreconfWhitelist.updatePreconfs, (add, _none())));
 
         vm.prank(OWNER);
-        gov.updatePreconfs(add, _none(), 200_000);
+        gov.updatePreconfsWithGasLimit(add, _none(), gasLimit);
     }
 
     function test_updatePreconfs_notOwner_reverts() external {
         vm.prank(alice);
         vm.expectRevert("Ownable: caller is not the owner");
-        gov.updatePreconfs(_one(address(0x1111), address(0x2222)), _none(), 200_000);
+        gov.updatePreconfs(_one(address(0x1111), address(0x2222)), _none());
+    }
+
+    function test_updatePreconfsWithGasLimit_notOwner_reverts() external {
+        vm.prank(alice);
+        vm.expectRevert("Ownable: caller is not the owner");
+        gov.updatePreconfsWithGasLimit(_one(address(0x1111), address(0x2222)), _none(), 200_000);
     }
 
     function test_updatePreconfs_whitelistNotSet_reverts() external {
@@ -165,7 +170,7 @@ contract PreconfWhitelistGov_Test is Portal_Initializer {
 
         vm.prank(OWNER);
         vm.expectRevert("PreconfWhitelistGov: whitelist not set");
-        fresh.updatePreconfs(_one(address(0x1111), address(0x2222)), _none(), 200_000);
+        fresh.updatePreconfs(_one(address(0x1111), address(0x2222)), _none());
     }
 
     // ===== guards this side runs so L2 does not have to pay for them =====
@@ -186,7 +191,7 @@ contract PreconfWhitelistGov_Test is Portal_Initializer {
 
         vm.prank(OWNER);
         vm.expectRevert("PreconfWhitelistGov: batch too large");
-        gov.updatePreconfs(add, _none(), 200_000);
+        gov.updatePreconfs(add, _none());
     }
 
     /// @notice The cap is on the sum across both arguments, matching the L2 contract.
@@ -201,29 +206,65 @@ contract PreconfWhitelistGov_Test is Portal_Initializer {
 
         vm.prank(OWNER);
         vm.expectRevert("PreconfWhitelistGov: batch too large");
-        gov.updatePreconfs(a, b, 200_000);
+        gov.updatePreconfs(a, b);
     }
 
-    /// @notice **The only floor left on `_gasLimit`, and it is the portal's.** This contract carries
-    ///         no gas estimate of its own: what a batch costs is a property of the L2 bytecode,
-    ///         which L1 cannot measure, so a constant here would be a stale copy that fails in the
-    ///         dangerous direction — under-estimating, and being trusted while it does.
-    ///
-    ///         What survives is `OptimismPortal.minimumGasLimit`, calibrated for calldata rather
-    ///         than execution. It rules out the absurd values without pretending to know the cost;
-    ///         sufficiency is checked by governance on L2, which is the only place it is knowable.
-    function test_updatePreconfs_belowPortalGasFloor_reverts() external {
+    /// @notice **On the explicit path the only floor is the portal's**, and it is calibrated for
+    ///         calldata rather than execution: it rules out the absurd values without pretending to
+    ///         know what a batch costs on L2. Sufficiency is the caller's problem here — that is the
+    ///         whole difference from `updatePreconfs`, which sizes the gas itself.
+    function test_updatePreconfsWithGasLimit_belowPortalGasFloor_reverts() external {
         PreconfWhitelist.Rule[] memory add = _one(address(0x1111), address(0x2222));
         bytes memory data = abi.encodeCall(PreconfWhitelist.updatePreconfs, (add, _none()));
         uint64 portalFloor = op.minimumGasLimit(uint64(data.length));
 
         vm.prank(OWNER);
         vm.expectRevert("OptimismPortal: gas limit too small");
-        gov.updatePreconfs(add, _none(), portalFloor - 1);
+        gov.updatePreconfsWithGasLimit(add, _none(), portalFloor - 1);
 
-        // Exactly the portal's floor is accepted, so this contract adds nothing above it.
+        // Exactly the portal's floor is accepted, so this contract adds nothing above it — a value
+        // that passes here can still starve the L2 call, which is why the default path exists.
         vm.prank(OWNER);
-        gov.updatePreconfs(add, _none(), portalFloor);
+        gov.updatePreconfsWithGasLimit(add, _none(), portalFloor);
+    }
+
+    /// @notice Zero is rejected rather than treated as "compute it": the two functions exist so that
+    ///         the multisig queue shows which path was taken, and a sentinel would erase that.
+    function test_updatePreconfsWithGasLimit_zero_reverts() external {
+        vm.prank(OWNER);
+        vm.expectRevert("PreconfWhitelistGov: gas limit is zero");
+        gov.updatePreconfsWithGasLimit(_one(address(0x1111), address(0x2222)), _none(), 0);
+    }
+
+    // ===== the computed gas limit =====
+
+    /// @notice The default path buys the portal's calldata floor plus `GAS_PER_RULE` per rule. The
+    ///         formula is re-derived here, and the 70,000 spelled out, so that changing either side
+    ///         of it takes two edits.
+    function test_updatePreconfs_buysTheComputedGasLimit_succeeds() external {
+        PreconfWhitelist.Rule[] memory add = _one(address(0x1111), address(0x2222));
+        PreconfWhitelist.Rule[] memory remove = _one(address(0x3333), address(0x4444));
+        bytes memory data = abi.encodeCall(PreconfWhitelist.updatePreconfs, (add, remove));
+        uint64 expected = op.minimumGasLimit(uint64(data.length)) + 2 * 70_000;
+
+        assertEq(gov.GAS_PER_RULE(), 70_000);
+        vm.expectEmit(true, true, true, true, address(gov));
+        emit GovernanceDeposited(whitelistL2, expected, data);
+
+        vm.prank(OWNER);
+        gov.updatePreconfs(add, remove);
+    }
+
+    /// @notice **The coupling that would otherwise break silently.** `GAS_PER_RULE` carries a margin
+    ///         over the measured cost, so the computed limit runs into `maxResourceLimit` before the
+    ///         batch cap does — at 282 rules against `MAX_BATCH`'s 256. Raising the cap past 281
+    ///         leaves the explicit path working and the default one reverting inside `metered`.
+    function test_updatePreconfs_computedLimitAtMaxBatchFitsTheDepositCap_succeeds() external view {
+        uint256 max = gov.MAX_BATCH();
+        uint64 calldataLen = uint64(132 + 64 * max); // selector + two offsets + two lengths + 64/rule
+        uint256 computed = op.minimumGasLimit(calldataLen) + gov.GAS_PER_RULE() * max;
+
+        assertLe(computed, op.SYSTEM_CONFIG().resourceConfig().maxResourceLimit);
     }
 
     // ===== rotateAuthorizedL1 =====
@@ -236,32 +277,56 @@ contract PreconfWhitelistGov_Test is Portal_Initializer {
     function test_rotateAuthorizedL1_eoa_reverts() external {
         vm.prank(OWNER);
         vm.expectRevert("PreconfWhitelistGov: authorized L1 sender is not a contract");
-        gov.rotateAuthorizedL1(alice, uint64(60_000));
+        gov.rotateAuthorizedL1(alice);
+    }
+
+    /// @notice Rotating to this contract is a no-op that still writes the slot and emits
+    ///         `AuthorizedL1Updated(gov, gov)` on L2 — the loudest event the system has, fired for
+    ///         nothing. It is rejected on L1, where rejecting it is still free.
+    function test_rotateAuthorizedL1_self_reverts() external {
+        vm.prank(OWNER);
+        vm.expectRevert("PreconfWhitelistGov: authorized L1 sender is this contract");
+        gov.rotateAuthorizedL1(address(gov));
     }
 
     function test_rotateAuthorizedL1_zeroAddress_reverts() external {
         vm.prank(OWNER);
         vm.expectRevert("PreconfWhitelistGov: authorized L1 sender is the zero address");
-        gov.rotateAuthorizedL1(address(0), uint64(60_000));
+        gov.rotateAuthorizedL1(address(0));
     }
 
     /// @notice A contract passes, and the deposit carries the `setAuthorizedL1` call rather than an
     ///         `updatePreconfs` one — the two paths share `_deposit`, so the calldata is the only
-    ///         thing that distinguishes them.
+    ///         thing that distinguishes them. The gas is `ROTATE_GAS` over the portal's floor, with
+    ///         no input involved: a rotation's cost on L2 does not depend on what is rotated to.
     function test_rotateAuthorizedL1_contract_succeeds() external {
         address newGov = address(new PreconfWhitelistGov(op, OWNER));
-        uint64 gasLimit = 60_000;
+        bytes memory data = abi.encodeCall(PreconfWhitelist.setAuthorizedL1, (newGov));
+        uint64 gasLimit = op.minimumGasLimit(uint64(data.length)) + gov.ROTATE_GAS();
 
         vm.expectEmit(true, true, true, true, address(op));
         emit TransactionDeposited(
-            AddressAliasHelper.applyL1ToL2Alias(address(gov)),
-            whitelistL2,
-            DEPOSIT_VERSION,
-            _opaque(gasLimit, abi.encodeCall(PreconfWhitelist.setAuthorizedL1, (newGov)))
+            AddressAliasHelper.applyL1ToL2Alias(address(gov)), whitelistL2, DEPOSIT_VERSION, _opaque(gasLimit, data)
         );
 
         vm.prank(OWNER);
-        gov.rotateAuthorizedL1(newGov, gasLimit);
+        gov.rotateAuthorizedL1(newGov);
+    }
+
+    /// @notice `ROTATE_GAS` measured against the real L2 function rather than asserted from the
+    ///         comment above it. Warm, though: the constructor touched the slot in this same
+    ///         transaction, so a real deposit pays a few thousand more for cold access.
+    function test_rotateAuthorizedL1_gasCoversTheL2Call_succeeds() external {
+        PreconfWhitelist wl = new PreconfWhitelist(address(gov), _none());
+        address newGov = address(new PreconfWhitelistGov(op, OWNER));
+
+        vm.prank(AddressAliasHelper.applyL1ToL2Alias(address(gov)));
+        uint256 before = gasleft();
+        wl.setAuthorizedL1(newGov);
+        uint256 used = before - gasleft();
+
+        assertLt(used, gov.ROTATE_GAS());
+        emit log_named_uint("setAuthorizedL1 gas", used);
     }
 
     function test_rotateAuthorizedL1_notOwner_reverts() external {
@@ -269,7 +334,7 @@ contract PreconfWhitelistGov_Test is Portal_Initializer {
 
         vm.prank(alice);
         vm.expectRevert("Ownable: caller is not the owner");
-        gov.rotateAuthorizedL1(newGov, uint64(60_000));
+        gov.rotateAuthorizedL1(newGov);
     }
 
     // ===== ownership =====


### PR DESCRIPTION
Add PreconfWhitelist, the on-chain authority for the sequencer's preconf allowlist, updated from
L1 over the standard CrossDomainMessenger. Authorization is an explicit (from, to) pair set plus two
wildcard sets, evaluated as a plain OR. The storage layout is load-bearing — op-reth reads slots
0/2/4 directly — so layoutVersion and the event topic0 are pinned on both sides. 41 forge tests.