### PR TITLE
docs: add VERSION.md, the cross-component version manifest

### DIFF
--- a/VERSION.md
+++ b/VERSION.md
@@ -1,0 +1,333 @@
+# Mantle Core Component Versions
+
+> Maintained per *Mantle Unified Version Management Specification V1.0* §3. Lives on the `main` branch of `mantle-xyz/mantle-v2`.
+>
+> **All core components of the same Mantle hardfork share `MAJOR.MINOR`; `PATCH` advances independently per component.**
+
+## 1. Scope
+
+**What this file is** — the single source of truth for *which component versions make up a given Mantle version*, and an index of every release in the current and previous round.
+
+**What this file is not** —
+
+- **Not a deployment dashboard.** It records *released* versions, not what each network (mainnet / sepolia / hoodi) currently runs. Live deployment state belongs to `mantle-config` and the K8s clusters, so this file never goes stale because of a canary or a rollback.
+- **Not a roadmap.** Only versions that have actually been released appear here. Planning, scheduling and code-name assignment live in the specification.
+- **Not an upstream dependency manifest.** Upstream versions (go-ethereum, reth, op-succinct, SP1, …) are decoupled from Mantle versions and maintained by each repo's own `go.mod` / `Cargo.toml`.
+- **Not a copy of the release notes.** Each release gets **one table row** here. The prose — what changed, why, how to upgrade — lives in the repo's GitHub Release and is linked from the version number. Never duplicate it into this file: it is what makes a changelog unmaintainable, and a copy drifts out of sync with the original.
+
+### Tracked components
+
+| Component | Repository | Role |
+|---|---|---|
+| op-geth | [mantle-xyz/op-geth](https://github.com/mantle-xyz/op-geth) | Execution layer |
+| op-node / op-batcher / op-gasoracle | [mantle-xyz/mantle-v2](https://github.com/mantle-xyz/mantle-v2) | Consensus layer, batching, gas oracle |
+| op-reth | [mantle-xyz/reth](https://github.com/mantle-xyz/reth) | Alternative execution layer |
+| op-succinct | [mantle-xyz/op-succinct](https://github.com/mantle-xyz/op-succinct) | Validity proving |
+| mantle-da-indexer | [mantle-xyz/mantle-da-indexer](https://github.com/mantle-xyz/mantle-da-indexer) | DA indexing |
+| lithosphere | [mantle-xyz/lithosphere](https://github.com/mantle-xyz/lithosphere) | Bridge indexing / API |
+
+Adding or removing a component is a specification-level change and requires review by the version owners (§5.6).
+
+### Where to look
+
+| I want to know… | Go to |
+|---|---|
+| What builds make up the current round | §2 |
+| Every release in the current round | §3.1 |
+| What actually changed in one release | click the version number → GitHub Release |
+| Which releases force a coordinated upgrade | §3, scan the **Consensus** column |
+| Every release of a past round | `docs/versions/<mantle-vX.Y>.md` (§3.3) |
+
+---
+
+## 2. Current Versions
+
+The newest released version of each component, under unified numbering. Current round: **`mantle-v1.6` (Elysium)**.
+
+| Component | Version | Released |
+|---|---|---|
+| op-geth | — | — |
+| mantle-v2 | — | — |
+| reth | — | — |
+| op-succinct | [`mantle-v1.6.0`](https://github.com/mantle-xyz/op-succinct/releases/tag/mantle-v1.6.0) | 2026-09-02 |
+| mantle-da-indexer | — | — |
+| lithosphere | — | — |
+
+`—` means the component has not yet cut a release under unified numbering; its first one is derived in §4.4.
+
+**This table is exactly six rows, forever.** It always shows the newest release per component — one screen, no scrolling, no history. History lives in §3.
+
+**It is never reset.** Rows roll onto a new `MINOR` one at a time, as each component ships on that round. During a round transition the table legitimately spans two rounds; that is what convergence looks like in progress, and it is why §5.8 checks same-`MINOR` alignment as a round-close gate rather than continuously.
+
+---
+
+## 3. Release Index
+
+One row per released tag. Newest first. Click the version for the full release note.
+
+**Upgrade**: `required` / `recommended` / `optional` — does an operator have to act.
+**Consensus**: `none` or `⚠ yes` — whether the release changes consensus or state transition. `none` is a commitment, not a default.
+
+### 3.1 `mantle-v1.6` — Elysium (current)
+
+| Version | Component | Date | Upgrade | Consensus | Summary |
+|---|---|---|---|---|---|
+| [`mantle-v1.6.0`](https://github.com/mantle-xyz/op-succinct/releases/tag/mantle-v1.6.0) | op-succinct | 2026-09-02 | recommended | none | Merge upstream op-succinct v3.12.0; first release under unified numbering |
+
+<!-- Add new rows directly below the header, newest first. Template in §5.5. -->
+
+### 3.2 `mantle-v1.5` — Arsia (previous)
+
+Retained for one round after close, then archived. Releases cut before this specification took effect are not backfilled; see each repo's GitHub Releases.
+
+### 3.3 Archived rounds
+
+| Round | Code name | Releases |
+|---|---|---|
+| — | — | *(none archived yet)* |
+
+Archive files are created by the round-transition PR (§5.3), never by a component release. Each is the round's §3 table moved verbatim under a minimal header:
+
+```markdown
+# mantle-v1.6 — Elysium
+
+Archived from VERSION.md §3 on <date>. Closed <date>.
+
+| Version | Component | Date | Upgrade | Consensus | Summary |
+|---|---|---|---|---|---|
+| …the table, verbatim…
+```
+
+---
+
+## 4. Versioning Rules
+
+### 4.1 Format
+
+```
+mantle-vMAJOR.MINOR.PATCH          release
+mantle-vMAJOR.MINOR.PATCH-rc.N     QA candidate
+```
+
+### 4.2 Field semantics
+
+| Field | Changes when | Notes |
+|---|---|---|
+| `MAJOR` | Fundamental rearchitecture of the node / protocol stack | Untouched by routine network upgrades; stays at `1` for the foreseeable future |
+| `MINOR` | Deliberately planned `+1`, roughly every 2–4 months | **Every tracked component in a round shares the same `MAJOR.MINOR`.** A round containing a hardfork gets a network code name; a round without one does not. A component with no real change may cut an empty version to stay aligned. Only the version owners may open a new `MINOR` (§5.3) |
+| `PATCH` | Grows **independently** per component within the current `MINOR` | Soft upgrades / soft forks, bugs, security, performance, RPC compatibility, circuit optimizations. **Never requires other repos to cut a matching version** |
+
+### 4.3 Why the `mantle-` prefix
+
+Half the tracked repositories carry upstream version lines that a bare `v1.6.x` would walk backwards:
+
+| Repository | Upstream / legacy line | Bare `v1.6.x` |
+|---|---|---|
+| op-geth, mantle-v2, mantle-da-indexer | already on `v1.x` | continues cleanly |
+| reth | `v2.2.1`, upstream `v1.9.3-*` | downgrade, and collides visually with upstream reth's own `v1.x` |
+| op-succinct | upstream `v4.x`, legacy `v3.8.1-*` | downgrade |
+| lithosphere | `v2.2.x` | downgrade; as a Go project `v2 → v1` violates Go module versioning |
+
+The `mantle-v` prefix opens a separate tag namespace, sidestepping monotonicity entirely while coexisting with each repo's upstream tag line. Docker tags, semver tooling and Go modules all stay well-defined.
+
+### 4.4 PATCH starting point on first adoption
+
+**A component's first unified version continues from the highest `PATCH` it has already consumed on that `MINOR` line, `+1`. A component with no release history on that `MINOR` starts at `.0`.**
+
+A `PATCH` counts as consumed once any tag has used it — including a QA candidate that never shipped, which is why this must be computed from the repository's tags, not from this file. A number is never reused or walked back within a `MINOR`, so *which build is `1.6.2`* always has exactly one answer.
+
+---
+
+## 5. Maintenance
+
+Two kinds of change land in this file, with different owners and different triggers:
+
+| Change | Trigger | Owner | Frequency |
+|---|---|---|---|
+| **Release** (§5.2) | a component cuts a tag | that repo's owner | ~35× per round |
+| **Round transition** (§5.3) | `MINOR` planning decision | version owners | once per round |
+
+Keeping these separate is deliberate: a component owner shipping a patch must never have to perform an org-level migration as a side effect.
+
+### 5.1 When to update
+
+**Within one working day of any tracked component cutting a release tag**, open a PR against `mantle-v2` `main`. The release is not complete until that PR merges.
+
+QA candidates (`-rc.N`) get no row. Note the `PATCH` they consumed in the **Summary** of the release that eventually ships.
+
+### 5.2 Updating for a release
+
+Two edits, both one line:
+
+1. **§2** — update that component's row with the new version and date.
+2. **§3.1** — insert one row at the top of the table.
+
+That is the whole job. A release PR touches nothing else — no archiving, no section moves, no changes to other components' rows.
+
+For the full end-to-end procedure — computing the version number, cutting the tag, classifying the fields — see §5.9.
+
+### 5.3 Round transition
+
+A round transition is **not** triggered by a tag, and is **never** performed by a component owner as a side effect of a release. It is a single, separately reviewed PR owned by the version owners.
+
+**Timing:** it lands at `MINOR` planning time — *before* any component cuts a tag on the new `MINOR`. The specification plans each round 2–4 months ahead with agreed scope, so this PR is part of opening that round, not an afterthought when someone happens to tag first.
+
+**One PR does all of it:**
+
+1. Move §3.2 — the round two back — verbatim into `docs/versions/<mantle-vX.Y>.md` using the header in §3.3, and add its row to §3.3.
+2. Promote the closing round from §3.1 into §3.2.
+3. Open an empty §3.1 for the new round, with its code name if it has one.
+4. Update the "Current round" line in §2.
+5. Verify the round-close gate: every component in §2 reached the closing round's `MAJOR.MINOR`. A component that shipped nothing must have cut an empty version (§4.2). Record any accepted exception in the archive file.
+
+**§2 itself is not touched** beyond step 4. Its rows keep showing each component's newest release and roll onto the new `MINOR` individually as those releases land.
+
+### 5.4 Worked example — one component releasing repeatedly
+
+The common case: `op-succinct` ships four times during `mantle-v1.6` while other components ship on their own cadence. Each release touches **two sections in two different ways**:
+
+| Section | On each release | Grows with releases? |
+|---|---|---|
+| §2 Current Versions | **overwrite** that component's row | No — always exactly six rows |
+| §3.1 Release Index | **append** one row | Yes — this is the only section that accumulates |
+
+After `mantle-v1.6.0` → `.1` → `.2` → `.3`, §2 shows only the newest:
+
+```markdown
+| op-succinct | [`mantle-v1.6.3`](…/releases/tag/mantle-v1.6.3) | 2026-11-04 |
+```
+
+…while §3.1 holds all four, interleaved by date with everyone else's releases:
+
+```markdown
+| [`mantle-v1.6.3`](…) | op-succinct | 2026-11-04 | required    | ⚠ yes | Range circuit vkey change; provers must upgrade in lockstep |
+| [`mantle-v1.6.2`](…) | op-geth     | 2026-10-20 | optional    | none  | … |
+| [`mantle-v1.6.2`](…) | op-succinct | 2026-10-11 | recommended | none  | SP1 v6.4.0; ~18% cheaper range proofs |
+| [`mantle-v1.6.1`](…) | op-succinct | 2026-09-24 | required    | none  | Fix proposer stall when the prover network returns FailedPrecondition |
+| [`mantle-v1.6.0`](…) | op-succinct | 2026-09-02 | recommended | none  | Merge upstream op-succinct v3.12.0 |
+```
+
+Note that `op-geth` and `op-succinct` both hold `mantle-v1.6.2` — expected, and exactly what §4.2 means by `PATCH` advancing independently. The `Component` column disambiguates; the pair *(version, component)* is the unique key.
+
+None of these four releases archives anything or opens a section. That happens once, later, in the round-transition PR (§5.3).
+
+To read one component's history in the round: `grep op-succinct VERSION.md`, or open that repo's releases page. §3.1 stays sorted by date because its primary question is *what shipped recently across the stack*.
+
+### 5.5 Row template
+
+```markdown
+| [`<tag>`](<release-note-url>) | <component> | <YYYY-MM-DD> | required\|recommended\|optional | none\|⚠ yes | <one line: what a reader needs to decide whether to care> |
+```
+
+The **Summary** is one line, grouped by user-visible change — not one phrase per PR. A feature split across 4 PRs is one clause. If a summary needs a second sentence, it belongs in the release note instead.
+
+Release-note content rules are in specification §5; reference example: [op-reth-v2.2.1-mantle-arsia.2](https://github.com/mantle-xyz/reth/releases/tag/op-reth-v2.2.1-mantle-arsia.2).
+
+### 5.6 Ownership
+
+| Role | Responsibility |
+|---|---|
+| Releasing repo's owner | Cuts the tag, publishes the release note, opens the release PR (§5.2) against `mantle-v2` |
+| Version owners | Review release PRs; **own the round-transition PR (§5.3)** including archive-file creation; approve `MINOR` planning, code names, round closure, and changes to the tracked-component list |
+| Release note final review | Sign-off on published release-note content per specification §5 |
+
+A tag with no release note is an incomplete release, not a released version.
+
+### 5.7 Automation
+
+Synchronising six repositories by hand will leak. Two mechanisms:
+
+- **Propagation.** An `on: push: tags` workflow in each tracked repo fires a `repository_dispatch` at `mantle-v2`; an Action opens the release PR with the §2 and §3.1 edits pre-filled from the tag and its release note. Humans review and sharpen the summary rather than transcribing.
+- **Verification.** CI on `mantle-v2` parses the §2 and §3 tables and asserts the invariants in §5.8. Because every entry is a table row rather than prose, this is a parse, not a heuristic — which is the main practical reason the format is tabular.
+
+The round transition (§5.3) is mechanical enough to script — moving a table into a new file and shifting section headers — but stays a reviewed, human-owned PR because it encodes a planning decision, not a mechanical consequence of a tag.
+
+### 5.8 Invariants
+
+CI-checkable on every PR:
+
+1. Every version in §2 exists as a tag in its repository and has a published GitHub Release.
+2. Every version in §2 appears as a row in §3.1 or §3.2.
+3. `PATCH` numbers within a `MINOR` are never reused or decreased for a given component.
+4. Every component listed in §1 appears exactly once in §2.
+5. §3 contains at most two round sections; older rounds resolve to a file under `docs/versions/`.
+
+Checked once, as a **round-close gate** in the §5.3 PR rather than continuously:
+
+6. Every component in §2 has reached the closing round's `MAJOR.MINOR`. Mid-round the table legitimately spans two rounds, so this cannot be a per-PR check.
+
+### 5.9 Executable procedure
+
+Written to be followed literally by a person or an agent. Everything needed to cut a release and update this file is specified here; nothing is left to taste.
+
+#### Step 1 — Preconditions
+
+Refuse to proceed unless all hold:
+
+- The `release/xxx` branch has QA approval and is **already merged into `main`** (specification §4).
+- `main` is green.
+- You know which component you are releasing.
+
+#### Step 2 — Compute the version number
+
+```
+MAJOR.MINOR := the round named in §2's "Current round" line.   # never change this yourself
+tags        := all tags in the component's repo matching mantle-v<MAJOR>.<MINOR>.*
+               (INCLUDING -rc.N tags — an rc consumes its PATCH, §4.4)
+
+if tags is non-empty:
+    PATCH := max(PATCH across tags) + 1
+else:
+    # first adoption — §4.4
+    legacy := all tags matching v<MAJOR>.<MINOR>.*  (the pre-prefix line, incl. -rc/-hotfix)
+    PATCH  := (legacy non-empty) ? max(PATCH across legacy) + 1 : 0
+
+version := mantle-v<MAJOR>.<MINOR>.<PATCH>
+```
+
+Read the tags from the repository (`git ls-remote --tags <repo>`), **not from this file** — rc tags never appear here, and using §2 alone will reuse a consumed `PATCH`.
+
+If `version` already exists as a tag: **stop and escalate.** Do not pick the next free number; a collision means the state assumed above is wrong.
+
+#### Step 3 — Cut the tag
+
+- Tag the **merge commit on `main`** produced by the release branch. Never tag a commit that is not on `main`.
+- Use an **annotated** tag (`git tag -a`), so the tag carries a tagger, date and message. Message: first line is the version, body is a two-to-three line summary. The release note, not the tag message, is authoritative.
+- Push the tag, then create the GitHub Release **from that existing tag** — do not let the GitHub UI create the tag, which would produce a lightweight one.
+
+#### Step 4 — Publish the release note
+
+Publish it **before** opening the VERSION.md PR: invariant 1 (§5.8) requires the Release to exist by the time the PR lands. Content rules are in specification §5.
+
+#### Step 5 — Classify the two graded fields
+
+**Upgrade** — what an operator has to do:
+
+| Value | Use when |
+|---|---|
+| `required` | Consensus or state-transition change, a security fix, or the previous version is broken or no longer interoperates with the network |
+| `recommended` | Meaningful bug fix, performance or compatibility improvement; safe to defer briefly |
+| `optional` | No operational impact — internal refactor, docs, tests, tooling |
+
+**Consensus** — `⚠ yes` if the change can alter block validity, state transition or proof verification: execution semantics, fork activation, precompile set, gas accounting, derivation rules, or a circuit / vkey change. Otherwise `none`.
+
+#### Step 6 — Open the VERSION.md PR
+
+Apply §5.2: overwrite the component's row in §2, insert one row at the top of §3.1 using the §5.5 template.
+
+**Date** is the tag's creation date in UTC (`git log -1 --format=%cd --date=short`), so the value is deterministic and CI-checkable.
+
+#### Prohibitions
+
+An agent performing this procedure must **never**:
+
+1. **Bump `MINOR`.** Only version owners open a round (§4.2, §5.3). If the computed version would start a new `MINOR`, stop and escalate.
+2. **Assert `Consensus: none` on its own.** `none` is a commitment (§3). Propose the value and require explicit confirmation from the releasing repo's owner before the PR merges.
+3. **Write a version into §2 that is not a pushed tag with a published Release.** This is invariant 1; violating it makes the file actively misleading for the next automated run.
+4. **Perform any §5.3 round-transition step** — archiving, section moves, opening a new §3.1 — as part of a release.
+5. **Edit or backfill historical rows.** Releases are append-only; a mistake is corrected by a follow-up row, not by rewriting history.
+6. **Infer the round from the tag it is about to cut.** The round comes from §2's "Current round" line, which only §5.3 may change.
+
+---
+
+<sub>Source: *Mantle Unified Version Management Specification V1.0*</sub>

--- a/VERSION.md
+++ b/VERSION.md
@@ -12,8 +12,8 @@
 
 - **Not a deployment dashboard.** It records *released* versions, not what each network (mainnet / sepolia / hoodi) currently runs. Live deployment state belongs to `mantle-config` and the K8s clusters, so this file never goes stale because of a canary or a rollback.
 - **Not a roadmap.** Only versions that have actually been released appear here. Planning, scheduling and code-name assignment live in the specification.
-- **Not an upstream dependency manifest.** Upstream versions (go-ethereum, reth, op-succinct, SP1, …) are decoupled from Mantle versions and maintained by each repo's own `go.mod` / `Cargo.toml`.
-- **Not a copy of the release notes.** Each release gets **one table row** here. The prose — what changed, why, how to upgrade — lives in the repo's GitHub Release and is linked from the version number. Never duplicate it into this file: it is what makes a changelog unmaintainable, and a copy drifts out of sync with the original.
+- **Not a copy of the numbering rules.** Format and field semantics live in the specification (§4.1).
+- **Not a copy of the release notes.** Each release gets **one table row** here, linking out. Never restate the prose: it is what makes a changelog unmaintainable, and a copy drifts out of sync with the original.
 
 ### Tracked components
 
@@ -36,28 +36,29 @@ Adding or removing a component is a specification-level change and requires revi
 | Every release in the current round | §3.1 |
 | What actually changed in one release | click the version number → GitHub Release |
 | Which releases force a coordinated upgrade | §3, scan the **Consensus** column |
+| What a past release depended on | §4.4 |
 | Every release of a past round | `docs/versions/<mantle-vX.Y>.md` (§3.3) |
 
 ---
 
 ## 2. Current Versions
 
-The newest released version of each component, under unified numbering. Current round: **`mantle-v1.6` (Elysium)**.
+Current round: **`mantle-v1.6` (Elysium)**.
 
-| Component | Version | Released |
-|---|---|---|
-| op-geth | — | — |
-| mantle-v2 | — | — |
-| reth | — | — |
-| op-succinct | [`mantle-v1.6.0`](https://github.com/mantle-xyz/op-succinct/releases/tag/mantle-v1.6.0) | 2026-09-02 |
-| mantle-da-indexer | — | — |
-| lithosphere | — | — |
+| Component | Unified version | Released | Previous version |
+|---|---|---|---|
+| op-geth | — | — | `v1.6.1` |
+| mantle-v2 | — | — | `v1.6.2` |
+| reth | — | — | `op-reth-v2.2.1-mantle-arsia.2` |
+| op-succinct | [`mantle-v1.6.0`](https://github.com/mantle-xyz/op-succinct/releases/tag/mantle-v1.6.0) | 2026-09-02 | `v3.8.1-testnet-mantle-arsia.2` |
+| mantle-da-indexer | — | — | `v1.6.0` |
+| lithosphere | — | — | `v2.2.12` |
 
-`—` means the component has not yet cut a release under unified numbering; its first one is derived in §4.4.
+**Previous version** is the component's newest tag under its pre-unified naming. It is there because `—` alone would read as *"never shipped"*, which is false — every component above has a live release. It is also the input §4.3 derives the first unified `PATCH` from. **The column is transitional:** a component's entry is dropped once it has adopted unified numbering, and the whole column goes away once all six have.
 
 **This table is exactly six rows, forever.** It always shows the newest release per component — one screen, no scrolling, no history. History lives in §3.
 
-**It is never reset.** Rows roll onto a new `MINOR` one at a time, as each component ships on that round. During a round transition the table legitimately spans two rounds; that is what convergence looks like in progress, and it is why §5.8 checks same-`MINOR` alignment as a round-close gate rather than continuously.
+**It is never reset.** Rows roll onto a new `MINOR` one at a time, as each component ships on that round. During a round transition the table legitimately spans two rounds; that is why §5.7 checks same-`MINOR` alignment as a round-close gate rather than continuously.
 
 ---
 
@@ -74,7 +75,7 @@ One row per released tag. Newest first. Click the version for the full release n
 |---|---|---|---|---|---|
 | [`mantle-v1.6.0`](https://github.com/mantle-xyz/op-succinct/releases/tag/mantle-v1.6.0) | op-succinct | 2026-09-02 | recommended | none | Merge upstream op-succinct v3.12.0; first release under unified numbering |
 
-<!-- Add new rows directly below the header, newest first. Template in §5.5. -->
+<!-- Insert new rows directly below the header, newest first. Template in §5.5. -->
 
 ### 3.2 `mantle-v1.5` — Arsia (previous)
 
@@ -86,55 +87,52 @@ Retained for one round after close, then archived. Releases cut before this spec
 |---|---|---|
 | — | — | *(none archived yet)* |
 
-Archive files are created by the round-transition PR (§5.3), never by a component release. Each is the round's §3 table moved verbatim under a minimal header:
-
-```markdown
-# mantle-v1.6 — Elysium
-
-Archived from VERSION.md §3 on <date>. Closed <date>.
-
-| Version | Component | Date | Upgrade | Consensus | Summary |
-|---|---|---|---|---|---|
-| …the table, verbatim…
-```
+Archive files are created by the round-transition PR (§5.3), never by a component release.
 
 ---
 
 ## 4. Versioning Rules
 
-### 4.1 Format
+### 4.1 Numbering
 
-```
-mantle-vMAJOR.MINOR.PATCH          release
-mantle-vMAJOR.MINOR.PATCH-rc.N     QA candidate
-```
+Tag format and the semantics of `MAJOR` / `MINOR` / `PATCH` are defined by *Mantle Unified Version Management Specification V1.0* §3 and are **not restated here** — one definition, one place to edit. Two consequences matter for reading this file:
 
-### 4.2 Field semantics
+- **`PATCH` advances independently per component** within a round, so two components legitimately hold the same version number. The pair *(version, component)* is the unique key, not the version alone.
+- **Only the version owners open a new `MINOR`** (§5.3). A release never infers its round; the round is an input.
 
-| Field | Changes when | Notes |
-|---|---|---|
-| `MAJOR` | Fundamental rearchitecture of the node / protocol stack | Untouched by routine network upgrades; stays at `1` for the foreseeable future |
-| `MINOR` | Deliberately planned `+1`, roughly every 2–4 months | **Every tracked component in a round shares the same `MAJOR.MINOR`.** A round containing a hardfork gets a network code name; a round without one does not. A component with no real change may cut an empty version to stay aligned. Only the version owners may open a new `MINOR` (§5.3) |
-| `PATCH` | Grows **independently** per component within the current `MINOR` | Soft upgrades / soft forks, bugs, security, performance, RPC compatibility, circuit optimizations. **Never requires other repos to cut a matching version** |
+This file deviates from the specification in exactly one respect — the tag prefix — for the reason below.
 
-### 4.3 Why the `mantle-` prefix
+### 4.2 Why the `mantle-v` prefix
 
-Half the tracked repositories carry upstream version lines that a bare `v1.6.x` would walk backwards:
+The specification writes `vMAJOR.MINOR.PATCH`. Tags here carry a `mantle-v` prefix because a bare number is a *version downgrade* for half the tracked repos: reth is on `v2.2.1` (upstream `v1.9.3-*`), op-succinct on `v3.8.1-*` (upstream `v4.x`), lithosphere on `v2.2.12` — and lithosphere is a Go project, where `v2 → v1` violates Go module versioning. The prefix opens a separate tag namespace, so Mantle numbering coexists with each repo's upstream line and Docker tags, semver tooling and Go modules all stay well-defined. `op-succinct` adopted it first, with `mantle-v1.6.0`.
 
-| Repository | Upstream / legacy line | Bare `v1.6.x` |
-|---|---|---|
-| op-geth, mantle-v2, mantle-da-indexer | already on `v1.x` | continues cleanly |
-| reth | `v2.2.1`, upstream `v1.9.3-*` | downgrade, and collides visually with upstream reth's own `v1.x` |
-| op-succinct | upstream `v4.x`, legacy `v3.8.1-*` | downgrade |
-| lithosphere | `v2.2.x` | downgrade; as a Go project `v2 → v1` violates Go module versioning |
-
-The `mantle-v` prefix opens a separate tag namespace, sidestepping monotonicity entirely while coexisting with each repo's upstream tag line. Docker tags, semver tooling and Go modules all stay well-defined.
-
-### 4.4 PATCH starting point on first adoption
+### 4.3 PATCH starting point on first adoption
 
 **A component's first unified version continues from the highest `PATCH` it has already consumed on that `MINOR` line, `+1`. A component with no release history on that `MINOR` starts at `.0`.**
 
-A `PATCH` counts as consumed once any tag has used it — including a QA candidate that never shipped, which is why this must be computed from the repository's tags, not from this file. A number is never reused or walked back within a `MINOR`, so *which build is `1.6.2`* always has exactly one answer.
+A `PATCH` counts as consumed once any tag has used it — including a QA candidate that never shipped, which is why this must be computed from the repository's tags and not from this file. A number is never reused or walked back within a `MINOR`, so *which build is `1.6.2`* always has exactly one answer.
+
+Implemented by `scripts/next-version.sh` (§5.8 step 2).
+
+### 4.4 Dependency pinning
+
+**A release must pin every inter-component and upstream dependency to an immutable ref — a tag or a commit sha, never a branch.** A branch is a moving target: the same tag rebuilt later resolves to different code, and the release stops being reproducible.
+
+Not hypothetical. In `mantle-xyz/reth`:
+
+| Tag | `mantle-v2` dependency | Reproducible |
+|---|---|---|
+| `op-reth-v2.2.1-mantle-arsia.1` | `branch = "mantle-elysium"` | no — rolling branch |
+| `op-reth-v2.2.1-mantle-arsia.2` | `tag = "v1.6.0"` | yes |
+
+Because manifests are themselves versioned, pinning also makes any past release's dependency set recoverable without this file having to record it:
+
+```bash
+git show <tag>:go.mod     | grep op-geth      # mantle-v2   -> op-geth
+git show <tag>:Cargo.toml | grep mantle-v2    # reth / op-succinct -> mantle-v2
+```
+
+Upstream versions (go-ethereum, reth, op-succinct, SP1, …) are decoupled from Mantle numbering and are maintained solely in each repo's `go.mod` / `Cargo.toml`.
 
 ---
 
@@ -151,7 +149,7 @@ Keeping these separate is deliberate: a component owner shipping a patch must ne
 
 ### 5.1 When to update
 
-**Within one working day of any tracked component cutting a release tag**, open a PR against `mantle-v2` `main`. The release is not complete until that PR merges.
+**Within one working day of any tracked component cutting a release tag**, open a PR against `mantle-v2` `main`. The release is not complete until that PR merges. Automating this propagation is out of scope for this file and tracked separately; until then it is a manual PR.
 
 QA candidates (`-rc.N`) get no row. Note the `PATCH` they consumed in the **Summary** of the release that eventually ships.
 
@@ -159,28 +157,16 @@ QA candidates (`-rc.N`) get no row. Note the `PATCH` they consumed in the **Summ
 
 Two edits, both one line:
 
-1. **§2** — update that component's row with the new version and date.
+1. **§2** — update that component's row with the new version and date; clear its **Previous version** cell if this is its first unified release.
 2. **§3.1** — insert one row at the top of the table.
 
-That is the whole job. A release PR touches nothing else — no archiving, no section moves, no changes to other components' rows.
-
-For the full end-to-end procedure — computing the version number, cutting the tag, classifying the fields — see §5.9.
+That is the whole job. A release PR touches nothing else — no archiving, no section moves, no changes to other components' rows. Full procedure in §5.8.
 
 ### 5.3 Round transition
 
-A round transition is **not** triggered by a tag, and is **never** performed by a component owner as a side effect of a release. It is a single, separately reviewed PR owned by the version owners.
+Closing a round and opening the next is **owned by the version owners** and lands as a **single separate PR** at `MINOR` planning time, before any component tags on the new `MINOR`. It is never triggered by a tag and never performed by a component owner as a side effect of a release.
 
-**Timing:** it lands at `MINOR` planning time — *before* any component cuts a tag on the new `MINOR`. The specification plans each round 2–4 months ahead with agreed scope, so this PR is part of opening that round, not an afterthought when someone happens to tag first.
-
-**One PR does all of it:**
-
-1. Move §3.2 — the round two back — verbatim into `docs/versions/<mantle-vX.Y>.md` using the header in §3.3, and add its row to §3.3.
-2. Promote the closing round from §3.1 into §3.2.
-3. Open an empty §3.1 for the new round, with its code name if it has one.
-4. Update the "Current round" line in §2.
-5. Verify the round-close gate: every component in §2 reached the closing round's `MAJOR.MINOR`. A component that shipped nothing must have cut an empty version (§4.2). Record any accepted exception in the archive file.
-
-**§2 itself is not touched** beyond step 4. Its rows keep showing each component's newest release and roll onto the new `MINOR` individually as those releases land.
+That PR archives the round two back to `docs/versions/<mantle-vX.Y>.md`, shifts §3.1 into §3.2, opens an empty §3.1, updates the current-round line in §2, and checks the round-close gate (§5.7). The step-by-step procedure is deliberately left undefined until the first real archival, which is at least one full round away.
 
 ### 5.4 Worked example — one component releasing repeatedly
 
@@ -189,12 +175,12 @@ The common case: `op-succinct` ships four times during `mantle-v1.6` while other
 | Section | On each release | Grows with releases? |
 |---|---|---|
 | §2 Current Versions | **overwrite** that component's row | No — always exactly six rows |
-| §3.1 Release Index | **append** one row | Yes — this is the only section that accumulates |
+| §3.1 Release Index | **insert** a row at the top | Yes — this is the only section that accumulates |
 
 After `mantle-v1.6.0` → `.1` → `.2` → `.3`, §2 shows only the newest:
 
 ```markdown
-| op-succinct | [`mantle-v1.6.3`](…/releases/tag/mantle-v1.6.3) | 2026-11-04 |
+| op-succinct | [`mantle-v1.6.3`](…/releases/tag/mantle-v1.6.3) | 2026-11-04 | |
 ```
 
 …while §3.1 holds all four, interleaved by date with everyone else's releases:
@@ -207,9 +193,7 @@ After `mantle-v1.6.0` → `.1` → `.2` → `.3`, §2 shows only the newest:
 | [`mantle-v1.6.0`](…) | op-succinct | 2026-09-02 | recommended | none  | Merge upstream op-succinct v3.12.0 |
 ```
 
-Note that `op-geth` and `op-succinct` both hold `mantle-v1.6.2` — expected, and exactly what §4.2 means by `PATCH` advancing independently. The `Component` column disambiguates; the pair *(version, component)* is the unique key.
-
-None of these four releases archives anything or opens a section. That happens once, later, in the round-transition PR (§5.3).
+`op-geth` and `op-succinct` both holding `mantle-v1.6.2` is expected — see §4.1. None of these four releases archives anything or opens a section; that happens once, later, in the round-transition PR (§5.3).
 
 To read one component's history in the round: `grep op-succinct VERSION.md`, or open that repo's releases page. §3.1 stays sorted by date because its primary question is *what shipped recently across the stack*.
 
@@ -227,27 +211,18 @@ Release-note content rules are in specification §5; reference example: [op-reth
 
 | Role | Responsibility |
 |---|---|
-| Releasing repo's owner | Cuts the tag, publishes the release note, opens the release PR (§5.2) against `mantle-v2` |
+| Releasing repo's owner | Cuts the tag, publishes the release note, opens the release PR (§5.2) |
 | Version owners | Review release PRs; **own the round-transition PR (§5.3)** including archive-file creation; approve `MINOR` planning, code names, round closure, and changes to the tracked-component list |
 | Release note final review | Sign-off on published release-note content per specification §5 |
 
 A tag with no release note is an incomplete release, not a released version.
 
-### 5.7 Automation
+### 5.7 Invariants
 
-Synchronising six repositories by hand will leak. Two mechanisms:
+Checkable on every PR:
 
-- **Propagation.** An `on: push: tags` workflow in each tracked repo fires a `repository_dispatch` at `mantle-v2`; an Action opens the release PR with the §2 and §3.1 edits pre-filled from the tag and its release note. Humans review and sharpen the summary rather than transcribing.
-- **Verification.** CI on `mantle-v2` parses the §2 and §3 tables and asserts the invariants in §5.8. Because every entry is a table row rather than prose, this is a parse, not a heuristic — which is the main practical reason the format is tabular.
-
-The round transition (§5.3) is mechanical enough to script — moving a table into a new file and shifting section headers — but stays a reviewed, human-owned PR because it encodes a planning decision, not a mechanical consequence of a tag.
-
-### 5.8 Invariants
-
-CI-checkable on every PR:
-
-1. Every version in §2 exists as a tag in its repository and has a published GitHub Release.
-2. Every version in §2 appears as a row in §3.1 or §3.2.
+1. Every unified version in §2 exists as a tag in its repository and has a published GitHub Release.
+2. Every unified version in §2 appears as a row in §3.1 or §3.2.
 3. `PATCH` numbers within a `MINOR` are never reused or decreased for a given component.
 4. Every component listed in §1 appears exactly once in §2.
 5. §3 contains at most two round sections; older rounds resolve to a file under `docs/versions/`.
@@ -256,77 +231,33 @@ Checked once, as a **round-close gate** in the §5.3 PR rather than continuously
 
 6. Every component in §2 has reached the closing round's `MAJOR.MINOR`. Mid-round the table legitimately spans two rounds, so this cannot be a per-PR check.
 
-### 5.9 Executable procedure
+### 5.8 Release procedure
 
-Written to be followed literally by a person or an agent. Everything needed to cut a release and update this file is specified here; nothing is left to taste.
+1. **Preconditions** — the `release/xxx` branch has QA approval and is already merged into `main` (specification §4); `main` is green.
+2. **Version number** — `scripts/next-version.sh <repo> <MAJOR.MINOR>`, which applies §4.3 against the repository's tags. `MAJOR.MINOR` is an input, taken from §2's current-round line. If the script reports a collision, stop and escalate — do not pick the next free number.
+3. **Tag** — annotated (`git tag -a`), on the release branch's merge commit on `main`; never a commit that is not on `main`. Push the tag, *then* create the GitHub Release from that existing tag, so the UI does not create a lightweight one instead.
+4. **Release note** — publish before opening the VERSION.md PR; invariant 1 requires it to exist by the time the PR lands.
+5. **VERSION.md PR** — apply §5.2. **Date** is the tag's creation date in UTC: `git log -1 --format=%cd --date=short <tag>`.
 
-#### Step 1 — Preconditions
+Grading the two judged fields:
 
-Refuse to proceed unless all hold:
-
-- The `release/xxx` branch has QA approval and is **already merged into `main`** (specification §4).
-- `main` is green.
-- You know which component you are releasing.
-
-#### Step 2 — Compute the version number
-
-```
-MAJOR.MINOR := the round named in §2's "Current round" line.   # never change this yourself
-tags        := all tags in the component's repo matching mantle-v<MAJOR>.<MINOR>.*
-               (INCLUDING -rc.N tags — an rc consumes its PATCH, §4.4)
-
-if tags is non-empty:
-    PATCH := max(PATCH across tags) + 1
-else:
-    # first adoption — §4.4
-    legacy := all tags matching v<MAJOR>.<MINOR>.*  (the pre-prefix line, incl. -rc/-hotfix)
-    PATCH  := (legacy non-empty) ? max(PATCH across legacy) + 1 : 0
-
-version := mantle-v<MAJOR>.<MINOR>.<PATCH>
-```
-
-Read the tags from the repository (`git ls-remote --tags <repo>`), **not from this file** — rc tags never appear here, and using §2 alone will reuse a consumed `PATCH`.
-
-If `version` already exists as a tag: **stop and escalate.** Do not pick the next free number; a collision means the state assumed above is wrong.
-
-#### Step 3 — Cut the tag
-
-- Tag the **merge commit on `main`** produced by the release branch. Never tag a commit that is not on `main`.
-- Use an **annotated** tag (`git tag -a`), so the tag carries a tagger, date and message. Message: first line is the version, body is a two-to-three line summary. The release note, not the tag message, is authoritative.
-- Push the tag, then create the GitHub Release **from that existing tag** — do not let the GitHub UI create the tag, which would produce a lightweight one.
-
-#### Step 4 — Publish the release note
-
-Publish it **before** opening the VERSION.md PR: invariant 1 (§5.8) requires the Release to exist by the time the PR lands. Content rules are in specification §5.
-
-#### Step 5 — Classify the two graded fields
-
-**Upgrade** — what an operator has to do:
-
-| Value | Use when |
+| `Upgrade` | Use when |
 |---|---|
-| `required` | Consensus or state-transition change, a security fix, or the previous version is broken or no longer interoperates with the network |
+| `required` | Consensus or state-transition change, a security fix, or the previous version no longer interoperates with the network |
 | `recommended` | Meaningful bug fix, performance or compatibility improvement; safe to defer briefly |
 | `optional` | No operational impact — internal refactor, docs, tests, tooling |
 
-**Consensus** — `⚠ yes` if the change can alter block validity, state transition or proof verification: execution semantics, fork activation, precompile set, gas accounting, derivation rules, or a circuit / vkey change. Otherwise `none`.
-
-#### Step 6 — Open the VERSION.md PR
-
-Apply §5.2: overwrite the component's row in §2, insert one row at the top of §3.1 using the §5.5 template.
-
-**Date** is the tag's creation date in UTC (`git log -1 --format=%cd --date=short`), so the value is deterministic and CI-checkable.
+`Consensus` is `⚠ yes` if the change can alter block validity, state transition or proof verification: execution semantics, fork activation, precompile set, gas accounting, derivation rules, or a circuit / vkey change. Otherwise `none`.
 
 #### Prohibitions
 
-An agent performing this procedure must **never**:
+An automated agent running this procedure must **never**:
 
-1. **Bump `MINOR`.** Only version owners open a round (§4.2, §5.3). If the computed version would start a new `MINOR`, stop and escalate.
-2. **Assert `Consensus: none` on its own.** `none` is a commitment (§3). Propose the value and require explicit confirmation from the releasing repo's owner before the PR merges.
-3. **Write a version into §2 that is not a pushed tag with a published Release.** This is invariant 1; violating it makes the file actively misleading for the next automated run.
-4. **Perform any §5.3 round-transition step** — archiving, section moves, opening a new §3.1 — as part of a release.
-5. **Edit or backfill historical rows.** Releases are append-only; a mistake is corrected by a follow-up row, not by rewriting history.
-6. **Infer the round from the tag it is about to cut.** The round comes from §2's "Current round" line, which only §5.3 may change.
+1. **Bump `MINOR`.** Only version owners open a round (§4.1, §5.3). If the next version would start one, stop and escalate.
+2. **Assert `Consensus: none` on its own.** `none` is a commitment (§3). Propose the value; require explicit confirmation from the releasing repo's owner before merge.
+3. **Write a version into §2 that is not a pushed tag with a published Release.** This is invariant 1; violating it corrupts the input to the next run.
+4. **Perform any §5.3 round-transition step** as part of a release.
+5. **Edit or backfill historical rows.** The index is append-only; a mistake is corrected by a new row, not by rewriting history.
 
 ---
 

--- a/scripts/next-version.sh
+++ b/scripts/next-version.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# Compute the next unified Mantle version for a component, per VERSION.md §4.3.
+#
+#   scripts/next-version.sh <repo-url-or-path> <MAJOR.MINOR>
+#
+#   scripts/next-version.sh https://github.com/mantle-xyz/op-geth 1.6   -> mantle-v1.6.2
+#   scripts/next-version.sh ../op-succinct 1.6                         -> mantle-v1.6.1
+#
+# Prints the tag to cut on stdout and the basis for it on stderr.
+# Exits 1 if the computed tag already exists — a collision means the assumed
+# state is wrong, so stop and escalate rather than picking the next free number.
+#
+# MAJOR.MINOR is an input, never inferred: only the version owners open a round
+# (VERSION.md §4.1, §5.3).
+
+set -euo pipefail
+
+repo=${1:-}
+mm=${2:-}
+if [ -z "$repo" ] || [ -z "$mm" ]; then
+  echo "usage: $0 <repo-url-or-path> <MAJOR.MINOR>" >&2
+  exit 2
+fi
+case $mm in
+  [0-9]*.[0-9]*) ;;
+  *) echo "error: MAJOR.MINOR must look like 1.6, got '$mm'" >&2; exit 2 ;;
+esac
+
+# Tags must come from the repository, never from VERSION.md: rc tags are not
+# recorded there, and using the file alone would reuse a consumed PATCH.
+if [ -e "$repo/.git" ]; then
+  all=$(git -C "$repo" tag -l)
+else
+  all=$(git ls-remote --tags "$repo" | sed 's#.*refs/tags/##' | grep -v '\^{}$')
+fi
+
+mm_re=$(printf '%s' "$mm" | sed 's/\./\\./g')
+
+# Highest PATCH already consumed under a given tag prefix. An -rc.N or -hotfix
+# suffix still counts: a candidate consumes its PATCH even if it never shipped.
+highest() {
+  printf '%s\n' "$all" \
+    | sed -n "s/^$1$mm_re\.\([0-9]\{1,\}\).*/\1/p" \
+    | sort -n | tail -1
+}
+
+unified=$(highest 'mantle-v')
+if [ -n "$unified" ]; then
+  patch=$((unified + 1))
+  basis="unified line: highest consumed PATCH is .$unified"
+else
+  legacy=$(highest 'v')
+  if [ -n "$legacy" ]; then
+    patch=$((legacy + 1))
+    basis="first adoption: legacy line's highest consumed PATCH is .$legacy"
+  else
+    patch=0
+    basis="first adoption: no release history on the $mm line"
+  fi
+fi
+
+version="mantle-v$mm.$patch"
+
+if printf '%s\n' "$all" | grep -qx -- "$version"; then
+  echo "error: $version already exists — stop and escalate (VERSION.md §5.8)" >&2
+  exit 1
+fi
+
+echo "basis: $basis" >&2
+echo "$version"


### PR DESCRIPTION
Implements the `VERSION.md` called for by *Mantle Unified Version Management Specification V1.0* §3 — a single source of truth in `mantle-v2` for which component versions make up a given Mantle version.

Tracks six components: **op-geth, mantle-v2, reth, op-succinct, mantle-da-indexer, lithosphere**.

## Design decisions worth reviewing

**1. Tags use a `mantle-vX.Y.Z` prefix, not a bare `vX.Y.Z`.**

The spec §3 writes `vMAJOR.MINOR.PATCH`, but a bare number is a *version downgrade* for half the tracked repos:

| Repo | Latest tag | Bare `v1.6.x` |
|---|---|---|
| op-geth / mantle-v2 / mantle-da-indexer | `v1.6.1` / `v1.6.2` / `v1.6.0` | continues cleanly |
| reth | `v2.2.1`, upstream `v1.9.3-*` | downgrade, collides with upstream reth's own `v1.x` |
| op-succinct | upstream `v4.8.0`, `v3.8.1-*` | downgrade |
| lithosphere | `v2.2.12` | downgrade; as a Go project `v2 → v1` violates Go module versioning |

The prefix opens a separate tag namespace and sidesteps monotonicity entirely. This matches the "Next" row of spec §2.2, and `op-succinct` already adopted it with `mantle-v1.6.0` on 2026-09-02.

**2. The release index is tabular, and only two rounds are retained.**

Measured from real history, a `MINOR` round sees ~5–7 releases per component (op-geth had 7 on the `1.5` line, lithosphere 17 on `2.2`). At six components that is ~35 releases per round. Prose entries would add ~800 lines a year. One table row per release, plus archiving rounds older than two to `docs/versions/`, keeps the file at a fixed size indefinitely.

**3. Release updates and round transitions are separated by owner and trigger.**

A component owner shipping a patch edits exactly two lines and touches nothing else. Archiving, section moves and opening a new round are a single separately-reviewed PR owned by the version owners, landed at `MINOR` planning time — never a side effect of whoever happens to tag first.

**4. §5.9 specifies the procedure end to end** — version-number computation, tag mechanics, field classification, step ordering, and explicit prohibitions for automated agents — so "cut a tag and update VERSION.md" is reproducible rather than improvised. The version-number algorithm was validated against all six repos' real tags and reproduces §4.4 exactly.

## Needs a decision before this is authoritative

- **§4.4 conflicts with the spec's §2.2 "Next" row.** The spec assigns op-geth `mantle-v1.6.1`, but that PATCH is already taken by the existing `v1.6.1`; deriving from actual tag history gives `mantle-v1.6.2`. Same for the `mantle-v1.6.3` / `mantle-v1.6.6` assigned to reth / op-succinct. This file follows tag history — please confirm which is authoritative.
- **Release notes are missing for 4 of 6 repos.** Only `reth` and `op-succinct` publish GitHub Releases today; the others carry bare tags. Invariant 1 (§5.8) requires a published Release per version, so this gap has to close before CI enforcement can be switched on.
- **`lithosphere` has shipped nothing since 2026-03-03**, predating Arsia. Either it does not follow the hardfork cadence and should leave unified numbering, or it needs an empty version to align.
- **Coverage** — `armory`, `op-infra`, `prove-network` and the `blockscout` family are still blank in spec §2.1 and are not tracked here yet.

`§2` is intentionally seeded with `—` for the five components that have not yet cut a unified version, so the file satisfies its own invariant 1 from day one rather than claiming tags that do not exist.