### PR TITLE
docs: add VERSION.md (minimal)

### DIFF
--- a/VERSION.md
+++ b/VERSION.md
@@ -1,0 +1,36 @@
+# Mantle Core Component Versions
+
+## Current Versions
+
+Current round: **`mantle-v1.6` (Elysium)**
+
+| Component | Version | Released | Previous version |
+|---|---|---|---|
+| op-geth | — | — | `v1.6.1` |
+| mantle-v2 | — | — | `v1.6.2` |
+| reth | — | — | `op-reth-v2.2.1-mantle-arsia.2` |
+| op-succinct | [`mantle-v1.6.0`](https://github.com/mantle-xyz/op-succinct/releases/tag/mantle-v1.6.0) | 2026-09-02 | `v3.8.1-testnet-mantle-arsia.2` |
+| mantle-da-indexer | — | — | `v1.6.0` |
+| lithosphere | — | — | `v2.2.12` |
+
+`—` means the component has not yet adopted unified numbering; **Previous version** is its newest tag under the old scheme, cleared once it adopts. `PATCH` advances independently per component, so two components can hold the same version number — the pair *(version, component)* is the unique key.
+
+## Release Index — `mantle-v1.6` (Elysium)
+
+- **Upgrade** — whether an operator has to act: `required` / `recommended` / `optional`.
+- **Consensus** — whether the release changes consensus or state transition. `none` is a commitment, not a default.
+
+| Version | Component | Date | Upgrade | Consensus | Summary |
+|---|---|---|---|---|---|
+| [`mantle-v1.6.0`](https://github.com/mantle-xyz/op-succinct/releases/tag/mantle-v1.6.0) | op-succinct | 2026-09-02 | recommended | none | Merge upstream op-succinct v3.12.0; first release under unified numbering |
+
+<!-- Insert new rows directly below the header, newest first. One line per release;
+     group by user-visible change, not per PR. Detail belongs in the release note. -->
+
+### Archived rounds
+
+| Round | Code name | Releases |
+|---|---|---|
+| — | — | *(none archived yet)* |
+
+When a round closes, the index above moves verbatim to `docs/versions/<mantle-vX.Y>.md` and gains a row here — so this file only ever carries the current round, at a fixed size no matter how many rounds pass.


### PR DESCRIPTION
Slim alternative to #374, at **36 lines** instead of 264, after feedback that the fuller version was too much document for what it manages.

Implements the cross-component manifest called for by *Mantle Unified Version Management Specification V1.0* §3, covering op-geth, mantle-v2, reth, op-succinct, mantle-da-indexer and lithosphere.

## What's in it

| Section | Contents |
|---|---|
| **Current Versions** | Six rows — newest release per component, plus a transitional `Previous version` column |
| **Release Index** | Current round only, one row per release, linking out to each GitHub Release |
| **Archived rounds** | Index of closed rounds moved to `docs/versions/` |

The table shapes and field legends are the reviewed versions from #374. `Previous version` is kept because a bare `—` reads as *"never shipped"*, which is false for all five components that have not yet adopted unified numbering; the column is cleared per component as each adopts, and disappears once all six have.

Only the current round lives in the file. When a round closes its table moves to `docs/versions/<mantle-vX.Y>.md` and gains a row under **Archived rounds**, so the file stays a fixed size regardless of how many rounds pass — at a measured ~35 releases per round, that is the property that matters.

## What was cut relative to #374

The introduction, the versioning rules restated from the specification, the maintenance and ownership sections, the six CI invariants, the release procedure and its agent prohibitions, previous-round retention, and `scripts/next-version.sh`.

## Two things that go with it

Worth deciding explicitly rather than by omission — both were dropped as document volume, but neither is only volume:

1. **"Who updates this, and how" is now unwritten.** Which row to touch after cutting a tag, who archives a closed round and when, when to clear a `Previous version` cell. Workable as convention; it was one of the reasons for writing the file down.
2. **The `PATCH`-derivation rule and the agent prohibitions are gone.** The derivation is not obvious — an `-rc.N` that never shipped still consumes its `PATCH`, so the next number has to be computed from repo tags rather than from this file. The prohibitions (never bump `MINOR`, never self-assert `Consensus: none`) exist because an agent asked to "cut a tag and update VERSION.md" will otherwise do both.

If both are wanted without re-inflating this file, they fit in a separate `docs/version-management.md` with a one-line link from here, leaving this at 36 lines for daily use. Happy to add that as a follow-up.

Also still open from #374, unaffected by trimming: the `PATCH` derivation disagrees with the spec §2.2 "Next" row on op-geth (`mantle-v1.6.2` vs `mantle-v1.6.1`), and four of the six repos publish no GitHub Releases, so the version links there resolve to bare tag pages.